### PR TITLE
fix: exit with status code 0 (no errors) after build is done

### DIFF
--- a/packages/fastify-vite/build.js
+++ b/packages/fastify-vite/build.js
@@ -42,6 +42,7 @@ async function build (options) {
   await Promise.all([viteBuild(client), viteBuild(server)])
   await move(join(serverOutDir, 'server.js'), join(serverOutDir, 'server.cjs'))
   console.log(`Generated ${outDir}/client and ${outDir}/server.`)
+  process.exit(0);
 }
 
 module.exports = { build }


### PR DESCRIPTION
When the build is done, you rely on another process to exit the code, but it exits the process with an exit code different than 0, which makes the CI process fail.