### PR TITLE
v2.3.0

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3,6 +3,9 @@
   - Fix code splitting for routes
   - Revisit data fetching idioms, maybe provide `usePayload` and `useRouteData`
 
+- React
+  - Upgrade to React Router v6
+
 - Documentation
   - Implement select box and click-to-copy like in https://stripe.com/docs/js/initializing
   - Add Undici fetch() examples

--- a/devinstall.mjs
+++ b/devinstall.mjs
@@ -1,12 +1,11 @@
-import { readdirSync, existsSync, writeFile, readFile } from 'fs/promises'
-import { join } from 'path'
-import { dirname } from 'desm'
+
+import { fileURLToPath } from 'url'
 
 $.quote = s => s
 
 const { entries } = Object
 
-let root = dirname(import.meta.url)
+let root = fileURLToPath(path.dirname(import.meta.url))
 let [example, exRoot, deps] = await parseArgv(root)
 
 let pkgInfos = {}
@@ -37,7 +36,7 @@ for (let pkg of deps.local) {
 
 async function getDeps (example, exRoot) {
   const examplePackage = await readJSON(`${root}/${exRoot}/package.dist.json`)
-  const pkgInfo = readdirSync(join(root, 'packages'))
+  const pkgInfo = await fs.readdir(path.join(root, 'packages'))
   return {
     local: Object.keys(examplePackage.dependencies).filter(dep => pkgInfo.includes(dep)),
     external: Object.keys(examplePackage.dependencies).filter(dep => !pkgInfo.includes(dep))
@@ -47,12 +46,12 @@ async function getDeps (example, exRoot) {
 async function parseArgv () {
   const example = process.argv[3]
   const exRoot = `examples/${example}`
-  const deps = await getDeps(join(exRoot, 'package.dist.json'), exRoot)
+  const deps = await getDeps(path.join(exRoot, 'package.dist.json'), exRoot)
   if (!example) {
     console.error('Usage: npm run devinstall -- <dir>')
     process.exit(1)
   }
-  if (!existsSync(join(root, exRoot))) {
+  if (!await fs.stat(path.join(root, exRoot))) {
     console.error(`Directory ${join(root, exRoot)} does not exist.`)
     process.exit(1)    
   }
@@ -60,10 +59,10 @@ async function parseArgv () {
 }
 
 async function readJSON(path) {
-  const json = await readFile(path, 'utf8')
+  const json = await fs.readFile(path, 'utf8')
   return JSON.parse(json)
 }
 
 async function writeJSON(path, contents) {
-  await writeFile(path, contents)
+  await fs.writeFile(path, contents)
 }

--- a/devinstall.mjs
+++ b/devinstall.mjs
@@ -51,7 +51,7 @@ async function parseArgv () {
     console.error('Usage: npm run devinstall -- <dir>')
     process.exit(1)
   }
-  if (!await fs.stat(path.join(root, exRoot))) {
+  if (!await fs.stat(path.join(root, exRoot)).catch(() => false)) {
     console.error(`Directory ${join(root, exRoot)} does not exist.`)
     process.exit(1)    
   }

--- a/examples/react-base/package.json
+++ b/examples/react-base/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "fastify": "^3.17.0",
-    "fastify-vite": "^2.2.4",
-    "fastify-vite-react": "^2.2.4"
+    "fastify-vite": "^2.3.0",
+    "fastify-vite-react": "^2.3.0"
   }
 }

--- a/examples/react-base/server.js
+++ b/examples/react-base/server.js
@@ -1,19 +1,20 @@
-const fastify = require('fastify')()
-const fastifyVite = require('fastify-vite')
-const fastifyViteReact = require('fastify-vite-react')
+const Fastify = require('fastify')
+const FastifyVite = require('fastify-vite')
+const FastifyViteReact = require('fastify-vite-react')
 
 async function main () {
-  await fastify.register(fastifyVite, {
+  const app = Fastify()
+  await app.register(FastifyVite, {
     root: __dirname,
-    renderer: fastifyViteReact,
+    renderer: FastifyViteReact,
   })
-  await fastify.vite.ready()
-  return fastify
+  await app.vite.commands()
+  return app
 }
 
 if (require.main === module) {
-  main().then((fastify) => {
-    fastify.listen(3000, (err, address) => {
+  main().then((app) => {
+    app.listen(3000, (err, address) => {
       if (err) {
         console.error(err)
         process.exit(1)

--- a/examples/react-data/package.json
+++ b/examples/react-data/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "fastify": "^3.17.0",
     "fastify-api": "^0.2.0",
-    "fastify-vite": "^2.2.4",
-    "fastify-vite-react": "^2.2.4"
+    "fastify-vite": "^2.3.0",
+    "fastify-vite-react": "^2.3.0"
   }
 }

--- a/examples/react-data/server.js
+++ b/examples/react-data/server.js
@@ -22,7 +22,7 @@ async function main () {
 
   app.vite.global = { foobar: 123 }
 
-  await app.vite.ready()
+  await app.vite.commands()
   return app
 }
 

--- a/examples/vue-base/package.json
+++ b/examples/vue-base/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "fastify": "^3.17.0",
-    "fastify-vite": "^2.2.4",
-    "fastify-vite-vue": "^2.2.4"
+    "fastify-vite": "^2.3.0",
+    "fastify-vite-vue": "^2.3.0"
   }
 }

--- a/examples/vue-base/server.js
+++ b/examples/vue-base/server.js
@@ -8,7 +8,7 @@ async function main () {
   const root = import.meta.url
 
   await app.register(FastifyVite, { root, renderer })
-  await app.vite.ready()
+  await app.vite.commands()
 
   return app
 }

--- a/examples/vue-data/package.json
+++ b/examples/vue-data/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "fastify": "^3.17.0",
     "fastify-api": "^0.2.0",
-    "fastify-vite": "^2.2.4",
-    "fastify-vite-vue": "^2.2.4"
+    "fastify-vite": "^2.3.0",
+    "fastify-vite-vue": "^2.3.0"
   }
 }

--- a/examples/vue-data/server.js
+++ b/examples/vue-data/server.js
@@ -22,7 +22,7 @@ async function main () {
 
   app.vite.global = { foobar: 123 }
 
-  await app.vite.ready()
+  await app.vite.commands()
   return app
 }
 

--- a/packages/fastify-vite-react/package.json
+++ b/packages/fastify-vite-react/package.json
@@ -34,7 +34,7 @@
     "type": "git",
     "url": "git+https://github.com/terixjs/fastify-vite.git"
   },
-  "version": "2.2.4",
+  "version": "2.3.0",
   "dependencies": {
     "@vitejs/plugin-react-refresh": "1.3.1",
     "devalue": "2.0.1",

--- a/packages/fastify-vite-vue/package.json
+++ b/packages/fastify-vite-vue/package.json
@@ -35,7 +35,7 @@
     "type": "git",
     "url": "git+https://github.com/terixjs/fastify-vite.git"
   },
-  "version": "2.2.4",
+  "version": "2.3.0",
   "dependencies": {
     "@vitejs/plugin-vue": "1.9.3",
     "@vitejs/plugin-vue-jsx": "1.2.0",

--- a/packages/fastify-vite/app.js
+++ b/packages/fastify-vite/app.js
@@ -9,7 +9,7 @@ function flattenPaths (viewPath) {
     return [viewPath]
   }
   if (Array.isArray(viewPath)) {
-    return viewPath;
+    return viewPath
   }
   return []
 }

--- a/packages/fastify-vite/build.js
+++ b/packages/fastify-vite/build.js
@@ -42,7 +42,7 @@ async function build (options) {
   await Promise.all([viteBuild(client), viteBuild(server)])
   await move(join(serverOutDir, 'server.js'), join(serverOutDir, 'server.cjs'))
   console.log(`Generated ${outDir}/client and ${outDir}/server.`)
-  process.exit(0);
+  process.exit(0)
 }
 
 module.exports = { build }

--- a/packages/fastify-vite/index.js
+++ b/packages/fastify-vite/index.js
@@ -200,6 +200,7 @@ async function fastifyVite (fastify, options) {
   }
 
   fastify.vite.commands = async () => {
+    await fastify.ready()
     if (fastify.vite.options.eject) {
       const force = process.argv.includes('--force')
       for (const blueprintFile of renderer.blueprint) {

--- a/packages/fastify-vite/index.js
+++ b/packages/fastify-vite/index.js
@@ -15,6 +15,17 @@ const { generateRoute } = require('./static')
 const { processOptions } = require('./options')
 
 async function fastifyVite (fastify, options) {
+  let viteReady
+  const isViteReady = new Promise((resolve) => {
+    viteReady = resolve
+  })
+
+  fastify.decorate('vite', {
+    ready () {
+      return isViteReady
+    },
+  })
+
   // Run options through Vite to get all Vite defaults taking vite.config.js
   // into account and ensuring options.root and options.vite.root are the same
   try {
@@ -99,9 +110,11 @@ async function fastifyVite (fastify, options) {
     }
   }
 
+  viteReady()
+
   // Sets fastify.vite.get() helper which uses
   // a wrapper for setting a route with a data() handler
-  fastify.decorate('vite', {
+  Object.assign(fastify.vite, {
     handler,
     options,
     global: undefined,
@@ -186,8 +199,7 @@ async function fastifyVite (fastify, options) {
     })
   }
 
-  fastify.vite.ready = async () => {
-    await fastify.ready()
+  fastify.vite.commands = async () => {
     if (fastify.vite.options.eject) {
       const force = process.argv.includes('--force')
       for (const blueprintFile of renderer.blueprint) {

--- a/packages/fastify-vite/package.json
+++ b/packages/fastify-vite/package.json
@@ -25,7 +25,7 @@
     "type": "git",
     "url": "git+https://github.com/terixjs/fastify-vite.git"
   },
-  "version": "2.2.4",
+  "version": "2.3.0",
   "dependencies": {
     "degit": "2.8.4",
     "fastify": "^3.17.0",


### PR DESCRIPTION
# Breaking

- `fastify.vite.ready()` now only awaits for **Vite** specifically, without also executing `fastify.ready()` also
- `fastify.vite.commands()` introduced to replace the original behavior of `fastify.vite.ready()`
  - it will specifically check and run [supported commands](https://fastify-vite.dev/concepts/builtin-commands.html) from the CLI 

Note: Minor and major releases will always have a PR for reference. 