### PR TITLE
feat(build): exit 0 after build success

### DIFF
--- a/packages/fastify-vite/index.js
+++ b/packages/fastify-vite/index.js
@@ -69,7 +69,7 @@ async function fastifyVite (fastify, options) {
 
   if (options.build) {
     await build(options)
-    setImmediate(() => process.exit())
+    setImmediate(() => process.exit(0))
   } else if (!options.eject) {
     // Setup appropriate Vite route handler
     if (options.dev) {


### PR DESCRIPTION
After the build succeeded, should specify exit with code zero.
CIs tools like CircleCI & GitHub Actions are failing when it's not zero.
