### PR TITLE
fix: issues with Windows file path

### DIFF
--- a/examples/react-hydration/package.json
+++ b/examples/react-hydration/package.json
@@ -1,8 +1,8 @@
 {
   "type": "module",
   "scripts": {
-    "dev": "node server.js --dev",
-    "devinstall": "zx ../../devinstall.mjs react-vanilla -- node server.js --dev",
+    "dev": "node ./server.js --dev",
+    "devinstall": "zx ../../devinstall.mjs react-vanilla -- node ./server.js --dev",
     "build": "npm run build:client && npm run build:server",
     "build:client": "vite build --outDir dist/client --ssrManifest",
     "build:server": "vite build --outDir dist/server --ssr /index.js",

--- a/examples/react-hydration/package.json
+++ b/examples/react-hydration/package.json
@@ -5,7 +5,7 @@
     "devinstall": "zx ../../devinstall.mjs react-vanilla -- node server.js --dev",
     "build": "npm run build:client && npm run build:server",
     "build:client": "vite build --outDir dist/client --ssrManifest",
-    "build:server": "vite build --outDir dist/server --ssr /index.js",
+    "build:server": "vite build --outDir dist/server --ssr ./index.js",
     "lint": "eslint . --ext .js,.jsx --fix"
   },
   "dependencies": {

--- a/examples/react-hydration/package.json
+++ b/examples/react-hydration/package.json
@@ -1,8 +1,8 @@
 {
   "type": "module",
   "scripts": {
-    "dev": "node ./server.js --dev",
-    "devinstall": "zx ../../devinstall.mjs react-vanilla -- node ./server.js --dev",
+    "dev": "node server.js --dev",
+    "devinstall": "zx ../../devinstall.mjs react-vanilla -- node server.js --dev",
     "build": "npm run build:client && npm run build:server",
     "build:client": "vite build --outDir dist/client --ssrManifest",
     "build:server": "vite build --outDir dist/server --ssr /index.js",

--- a/examples/react-hydration/vite.config.js
+++ b/examples/react-hydration/vite.config.js
@@ -1,10 +1,9 @@
-import { join, dirname } from 'path'
 import viteReact from '@vitejs/plugin-react'
 import viteFastify from 'fastify-vite/plugin'
 
 // @type {import('vite').UserConfig}
 export default {
-  root: join(dirname(new URL(import.meta.url).pathname), 'client'),
+  root: './client',
   plugins: [
     viteReact({ jsxRuntime: 'classic' }),
     viteFastify(),

--- a/examples/react-next/package.json
+++ b/examples/react-next/package.json
@@ -1,8 +1,8 @@
 {
   "type": "module",
   "scripts": {
-    "dev": "node server.js --dev",
-    "devinstall": "zx ../../devinstall.mjs react-vanilla -- node server.js --dev",
+    "dev": "node ./server.js --dev",
+    "devinstall": "zx ../../devinstall.mjs react-vanilla -- node ./server.js --dev",
     "build": "npm run build:client && npm run build:server",
     "build:client": "vite build --outDir dist/client --ssrManifest",
     "build:server": "vite build --outDir dist/server --ssr /index.js",

--- a/examples/react-next/package.json
+++ b/examples/react-next/package.json
@@ -5,7 +5,7 @@
     "devinstall": "zx ../../devinstall.mjs react-vanilla -- node server.js --dev",
     "build": "npm run build:client && npm run build:server",
     "build:client": "vite build --outDir dist/client --ssrManifest",
-    "build:server": "vite build --outDir dist/server --ssr /index.js",
+    "build:server": "vite build --outDir dist/server --ssr ./index.js",
     "lint": "eslint . --ext .js,.jsx --fix"
   },
   "dependencies": {

--- a/examples/react-next/package.json
+++ b/examples/react-next/package.json
@@ -1,8 +1,8 @@
 {
   "type": "module",
   "scripts": {
-    "dev": "node ./server.js --dev",
-    "devinstall": "zx ../../devinstall.mjs react-vanilla -- node ./server.js --dev",
+    "dev": "node server.js --dev",
+    "devinstall": "zx ../../devinstall.mjs react-vanilla -- node server.js --dev",
     "build": "npm run build:client && npm run build:server",
     "build:client": "vite build --outDir dist/client --ssrManifest",
     "build:server": "vite build --outDir dist/server --ssr /index.js",

--- a/examples/react-next/vite.config.js
+++ b/examples/react-next/vite.config.js
@@ -1,10 +1,9 @@
-import { join, dirname } from 'path'
 import viteReact from '@vitejs/plugin-react'
 import viteFastify from 'fastify-vite/plugin'
 
 // @type {import('vite').UserConfig}
 export default {
-  root: join(dirname(new URL(import.meta.url).pathname), 'client'),
+  root: './client',
   plugins: [
     viteReact({ jsxRuntime: 'classic' }),
     viteFastify(),

--- a/examples/react-streaming/package.json
+++ b/examples/react-streaming/package.json
@@ -1,8 +1,8 @@
 {
   "type": "module",
   "scripts": {
-    "dev": "node server.js --dev",
-    "devinstall": "zx ../../devinstall.mjs react-vanilla -- node server.js --dev",
+    "dev": "node ./server.js --dev",
+    "devinstall": "zx ../../devinstall.mjs react-vanilla -- node ./server.js --dev",
     "build": "npm run build:client && npm run build:server",
     "build:client": "vite build --outDir dist/client --ssrManifest",
     "build:server": "vite build --outDir dist/server --ssr /index.js",

--- a/examples/react-streaming/package.json
+++ b/examples/react-streaming/package.json
@@ -5,7 +5,7 @@
     "devinstall": "zx ../../devinstall.mjs react-vanilla -- node server.js --dev",
     "build": "npm run build:client && npm run build:server",
     "build:client": "vite build --outDir dist/client --ssrManifest",
-    "build:server": "vite build --outDir dist/server --ssr /index.js",
+    "build:server": "vite build --outDir dist/server --ssr ./index.js",
     "lint": "eslint . --ext .js,.jsx --fix"
   },
   "dependencies": {

--- a/examples/react-streaming/package.json
+++ b/examples/react-streaming/package.json
@@ -1,8 +1,8 @@
 {
   "type": "module",
   "scripts": {
-    "dev": "node ./server.js --dev",
-    "devinstall": "zx ../../devinstall.mjs react-vanilla -- node ./server.js --dev",
+    "dev": "node server.js --dev",
+    "devinstall": "zx ../../devinstall.mjs react-vanilla -- node server.js --dev",
     "build": "npm run build:client && npm run build:server",
     "build:client": "vite build --outDir dist/client --ssrManifest",
     "build:server": "vite build --outDir dist/server --ssr /index.js",

--- a/examples/react-streaming/vite.config.js
+++ b/examples/react-streaming/vite.config.js
@@ -1,10 +1,9 @@
-import { join, dirname } from 'path'
 import viteReact from '@vitejs/plugin-react'
 import viteFastify from 'fastify-vite/plugin'
 
 // @type {import('vite').UserConfig}
 export default {
-  root: join(dirname(new URL(import.meta.url).pathname), 'client'),
+  root: './client',
   plugins: [
     viteReact({ jsxRuntime: 'classic' }),
     viteFastify(),

--- a/examples/react-vanilla/package.json
+++ b/examples/react-vanilla/package.json
@@ -1,8 +1,8 @@
 {
   "type": "module",
   "scripts": {
-    "dev": "node server.js --dev",
-    "devinstall": "zx ../../devinstall.mjs react-vanilla -- node server.js --dev",
+    "dev": "node ./server.js --dev",
+    "devinstall": "zx ../../devinstall.mjs react-vanilla -- node ./server.js --dev",
     "build": "npm run build:client && npm run build:server",
     "build:client": "vite build --outDir dist/client --ssrManifest",
     "build:server": "vite build --outDir dist/server --ssr /index.js",

--- a/examples/react-vanilla/package.json
+++ b/examples/react-vanilla/package.json
@@ -5,7 +5,7 @@
     "devinstall": "zx ../../devinstall.mjs react-vanilla -- node server.js --dev",
     "build": "npm run build:client && npm run build:server",
     "build:client": "vite build --outDir dist/client --ssrManifest",
-    "build:server": "vite build --outDir dist/server --ssr /index.js",
+    "build:server": "vite build --outDir dist/server --ssr ./index.js",
     "lint": "eslint . --ext .js,.jsx --fix"
   },
   "dependencies": {

--- a/examples/react-vanilla/package.json
+++ b/examples/react-vanilla/package.json
@@ -1,8 +1,8 @@
 {
   "type": "module",
   "scripts": {
-    "dev": "node ./server.js --dev",
-    "devinstall": "zx ../../devinstall.mjs react-vanilla -- node ./server.js --dev",
+    "dev": "node server.js --dev",
+    "devinstall": "zx ../../devinstall.mjs react-vanilla -- node server.js --dev",
     "build": "npm run build:client && npm run build:server",
     "build:client": "vite build --outDir dist/client --ssrManifest",
     "build:server": "vite build --outDir dist/server --ssr /index.js",

--- a/examples/react-vanilla/vite.config.js
+++ b/examples/react-vanilla/vite.config.js
@@ -1,10 +1,9 @@
-import { join, dirname } from 'path'
 import viteReact from '@vitejs/plugin-react'
 import viteFastify from 'fastify-vite/plugin'
 
 // @type {import('vite').UserConfig}
 export default {
-  root: join(dirname(new URL(import.meta.url).pathname), 'client'),
+  root: './client',
   plugins: [
     viteReact({ jsxRuntime: 'classic' }),
     viteFastify(),

--- a/examples/solid-hydration/package.json
+++ b/examples/solid-hydration/package.json
@@ -1,8 +1,8 @@
 {
   "type": "module",
   "scripts": {
-    "dev": "node server --dev",
-    "devinstall": "zx ../../devinstall.mjs solid-vanilla -- node server --dev",
+    "dev": "node server.js --dev",
+    "devinstall": "zx ../../devinstall.mjs solid-vanilla -- node server.js --dev",
     "build": "npm run build:client && npm run build:server",
     "build:client": "vite build --outDir dist/client --ssrManifest",
     "build:server": "vite build --outDir dist/server --ssr /index.js",

--- a/examples/solid-hydration/package.json
+++ b/examples/solid-hydration/package.json
@@ -1,8 +1,8 @@
 {
   "type": "module",
   "scripts": {
-    "dev": "node ./server --dev",
-    "devinstall": "zx ../../devinstall.mjs solid-vanilla -- node ./server --dev",
+    "dev": "node server --dev",
+    "devinstall": "zx ../../devinstall.mjs solid-vanilla -- node server --dev",
     "build": "npm run build:client && npm run build:server",
     "build:client": "vite build --outDir dist/client --ssrManifest",
     "build:server": "vite build --outDir dist/server --ssr /index.js",

--- a/examples/solid-hydration/package.json
+++ b/examples/solid-hydration/package.json
@@ -1,8 +1,8 @@
 {
   "type": "module",
   "scripts": {
-    "dev": "node server.js --dev",
-    "devinstall": "zx ../../devinstall.mjs solid-vanilla -- node server.js --dev",
+    "dev": "node ./server --dev",
+    "devinstall": "zx ../../devinstall.mjs solid-vanilla -- node ./server --dev",
     "build": "npm run build:client && npm run build:server",
     "build:client": "vite build --outDir dist/client --ssrManifest",
     "build:server": "vite build --outDir dist/server --ssr /index.js",

--- a/examples/solid-hydration/package.json
+++ b/examples/solid-hydration/package.json
@@ -5,7 +5,7 @@
     "devinstall": "zx ../../devinstall.mjs solid-vanilla -- node server.js --dev",
     "build": "npm run build:client && npm run build:server",
     "build:client": "vite build --outDir dist/client --ssrManifest",
-    "build:server": "vite build --outDir dist/server --ssr /index.js",
+    "build:server": "vite build --outDir dist/server --ssr ./index.js",
     "lint": "eslint . --ext .js,.jsx"
   },
   "dependencies": {

--- a/examples/solid-hydration/vite.config.js
+++ b/examples/solid-hydration/vite.config.js
@@ -1,10 +1,9 @@
-import { join, dirname } from 'path'
 import viteSolid from 'vite-plugin-solid'
 import viteFastify from 'fastify-vite/plugin'
 
 // @type {import('vite').UserConfig}
 export default {
-  root: join(dirname(new URL(import.meta.url).pathname), 'client'),
+  root: './client',
   plugins: [
     viteSolid({ ssr: true }),
     viteFastify(),

--- a/examples/solid-vanilla/package.json
+++ b/examples/solid-vanilla/package.json
@@ -5,7 +5,7 @@
     "devinstall": "zx ../../devinstall.mjs solid-vanilla -- node server.js --dev",
     "build": "npm run build:client && npm run build:server",
     "build:client": "vite build --outDir dist/client --ssrManifest",
-    "build:server": "vite build --outDir dist/server --ssr /index.js",
+    "build:server": "vite build --outDir dist/server --ssr ./index.js",
     "lint": "eslint . --ext .js,.jsx --fix"
   },
   "dependencies": {

--- a/examples/solid-vanilla/package.json
+++ b/examples/solid-vanilla/package.json
@@ -1,8 +1,8 @@
 {
   "type": "module",
   "scripts": {
-    "dev": "node server --dev",
-    "devinstall": "zx ../../devinstall.mjs solid-vanilla -- node server --dev",
+    "dev": "node server.js --dev",
+    "devinstall": "zx ../../devinstall.mjs solid-vanilla -- node server.js --dev",
     "build": "npm run build:client && npm run build:server",
     "build:client": "vite build --outDir dist/client --ssrManifest",
     "build:server": "vite build --outDir dist/server --ssr /index.js",

--- a/examples/solid-vanilla/package.json
+++ b/examples/solid-vanilla/package.json
@@ -1,8 +1,8 @@
 {
   "type": "module",
   "scripts": {
-    "dev": "node ./server --dev",
-    "devinstall": "zx ../../devinstall.mjs solid-vanilla -- node ./server --dev",
+    "dev": "node server --dev",
+    "devinstall": "zx ../../devinstall.mjs solid-vanilla -- node server --dev",
     "build": "npm run build:client && npm run build:server",
     "build:client": "vite build --outDir dist/client --ssrManifest",
     "build:server": "vite build --outDir dist/server --ssr /index.js",

--- a/examples/solid-vanilla/package.json
+++ b/examples/solid-vanilla/package.json
@@ -1,8 +1,8 @@
 {
   "type": "module",
   "scripts": {
-    "dev": "node server.js --dev",
-    "devinstall": "zx ../../devinstall.mjs solid-vanilla -- node server.js --dev",
+    "dev": "node ./server --dev",
+    "devinstall": "zx ../../devinstall.mjs solid-vanilla -- node ./server --dev",
     "build": "npm run build:client && npm run build:server",
     "build:client": "vite build --outDir dist/client --ssrManifest",
     "build:server": "vite build --outDir dist/server --ssr /index.js",

--- a/examples/solid-vanilla/vite.config.js
+++ b/examples/solid-vanilla/vite.config.js
@@ -1,10 +1,9 @@
-import { join, dirname } from 'path'
 import viteSolid from 'vite-plugin-solid'
 import viteFastify from 'fastify-vite/plugin'
 
 // @type {import('vite').UserConfig}
 export default {
-  root: join(dirname(new URL(import.meta.url).pathname), 'client'),
+  root: './client',
   plugins: [
     viteSolid({ ssr: true }),
     viteFastify(),

--- a/examples/svelte-hydration/package.json
+++ b/examples/svelte-hydration/package.json
@@ -1,8 +1,8 @@
 {
   "type": "module",
   "scripts": {
-    "dev": "node server.js --dev",
-    "devinstall": "zx ../../devinstall.mjs svelte-hydration -- node server.js --dev",
+    "dev": "node ./server --dev",
+    "devinstall": "zx ../../devinstall.mjs svelte-hydration -- node ./server --dev",
     "build": "npm run build:client && npm run build:server",
     "build:client": "vite build --outDir dist/client --ssrManifest",
     "build:server": "vite build --outDir dist/server --ssr /index.js",

--- a/examples/svelte-hydration/package.json
+++ b/examples/svelte-hydration/package.json
@@ -5,7 +5,7 @@
     "devinstall": "zx ../../devinstall.mjs svelte-hydration -- node server.js --dev",
     "build": "npm run build:client && npm run build:server",
     "build:client": "vite build --outDir dist/client --ssrManifest",
-    "build:server": "vite build --outDir dist/server --ssr /index.js",
+    "build:server": "vite build --outDir dist/server --ssr ./index.js",
     "lint": "eslint . --ext .js,.jsx --fix"
   },
   "dependencies": {

--- a/examples/svelte-hydration/package.json
+++ b/examples/svelte-hydration/package.json
@@ -1,8 +1,8 @@
 {
   "type": "module",
   "scripts": {
-    "dev": "node ./server --dev",
-    "devinstall": "zx ../../devinstall.mjs svelte-hydration -- node ./server --dev",
+    "dev": "node server --dev",
+    "devinstall": "zx ../../devinstall.mjs svelte-hydration -- node server --dev",
     "build": "npm run build:client && npm run build:server",
     "build:client": "vite build --outDir dist/client --ssrManifest",
     "build:server": "vite build --outDir dist/server --ssr /index.js",

--- a/examples/svelte-hydration/package.json
+++ b/examples/svelte-hydration/package.json
@@ -1,8 +1,8 @@
 {
   "type": "module",
   "scripts": {
-    "dev": "node server --dev",
-    "devinstall": "zx ../../devinstall.mjs svelte-hydration -- node server --dev",
+    "dev": "node server.js --dev",
+    "devinstall": "zx ../../devinstall.mjs svelte-hydration -- node server.js --dev",
     "build": "npm run build:client && npm run build:server",
     "build:client": "vite build --outDir dist/client --ssrManifest",
     "build:server": "vite build --outDir dist/server --ssr /index.js",

--- a/examples/svelte-hydration/vite.config.js
+++ b/examples/svelte-hydration/vite.config.js
@@ -1,10 +1,9 @@
-import { join, dirname } from 'path'
 import { svelte as viteSvelte } from '@sveltejs/vite-plugin-svelte'
 import viteFastify from 'fastify-vite/plugin'
 
 // @type {import('vite').UserConfig}
 export default {
-  root: join(dirname(new URL(import.meta.url).pathname), 'client'),
+  root: './client',
   plugins: [
     viteSvelte({
       compilerOptions: {

--- a/examples/svelte-vanilla/package.json
+++ b/examples/svelte-vanilla/package.json
@@ -5,7 +5,7 @@
     "devinstall": "zx ../../devinstall.mjs solid-vanilla -- node server.js --dev",
     "build": "npm run build:client && npm run build:server",
     "build:client": "vite build --outDir dist/client --ssrManifest",
-    "build:server": "vite build --outDir dist/server --ssr /index.js",
+    "build:server": "vite build --outDir dist/server --ssr ./index.js",
     "lint": "eslint . --ext .js,.jsx --fix"
   },
   "dependencies": {

--- a/examples/svelte-vanilla/package.json
+++ b/examples/svelte-vanilla/package.json
@@ -1,8 +1,8 @@
 {
   "type": "module",
   "scripts": {
-    "dev": "node server --dev",
-    "devinstall": "zx ../../devinstall.mjs solid-vanilla -- node server --dev",
+    "dev": "node server.js --dev",
+    "devinstall": "zx ../../devinstall.mjs solid-vanilla -- node server.js --dev",
     "build": "npm run build:client && npm run build:server",
     "build:client": "vite build --outDir dist/client --ssrManifest",
     "build:server": "vite build --outDir dist/server --ssr /index.js",

--- a/examples/svelte-vanilla/package.json
+++ b/examples/svelte-vanilla/package.json
@@ -1,8 +1,8 @@
 {
   "type": "module",
   "scripts": {
-    "dev": "node ./server --dev",
-    "devinstall": "zx ../../devinstall.mjs solid-vanilla -- node ./server --dev",
+    "dev": "node server --dev",
+    "devinstall": "zx ../../devinstall.mjs solid-vanilla -- node server --dev",
     "build": "npm run build:client && npm run build:server",
     "build:client": "vite build --outDir dist/client --ssrManifest",
     "build:server": "vite build --outDir dist/server --ssr /index.js",

--- a/examples/svelte-vanilla/package.json
+++ b/examples/svelte-vanilla/package.json
@@ -1,8 +1,8 @@
 {
   "type": "module",
   "scripts": {
-    "dev": "node server.js --dev",
-    "devinstall": "zx ../../devinstall.mjs solid-vanilla -- node server.js --dev",
+    "dev": "node ./server --dev",
+    "devinstall": "zx ../../devinstall.mjs solid-vanilla -- node ./server --dev",
     "build": "npm run build:client && npm run build:server",
     "build:client": "vite build --outDir dist/client --ssrManifest",
     "build:server": "vite build --outDir dist/server --ssr /index.js",

--- a/examples/svelte-vanilla/vite.config.js
+++ b/examples/svelte-vanilla/vite.config.js
@@ -1,10 +1,9 @@
-import { join, dirname } from 'path'
 import { svelte as viteSvelte } from '@sveltejs/vite-plugin-svelte'
 import viteFastify from 'fastify-vite/plugin'
 
 // @type {import('vite').UserConfig}
 export default {
-  root: join(dirname(new URL(import.meta.url).pathname), 'client'),
+  root: './client',
   plugins: [
     viteSvelte(),
     viteFastify(),

--- a/examples/vue-hydration/package.json
+++ b/examples/vue-hydration/package.json
@@ -1,8 +1,8 @@
 {
   "type": "module",
   "scripts": {
-    "dev": "node server.js --dev",
-    "devinstall": "zx ../../devinstall.mjs vue-vanilla -- node server.js --dev",
+    "dev": "node ./server --dev",
+    "devinstall": "zx ../../devinstall.mjs vue-vanilla -- node ./server --dev",
     "build": "npm run build:client && npm run build:server",
     "build:client": "vite build --outDir dist/client --ssrManifest",
     "build:server": "vite build --outDir dist/server --ssr /index.js",

--- a/examples/vue-hydration/package.json
+++ b/examples/vue-hydration/package.json
@@ -5,7 +5,7 @@
     "devinstall": "zx ../../devinstall.mjs vue-vanilla -- node server.js --dev",
     "build": "npm run build:client && npm run build:server",
     "build:client": "vite build --outDir dist/client --ssrManifest",
-    "build:server": "vite build --outDir dist/server --ssr /index.js",
+    "build:server": "vite build --outDir dist/server --ssr ./index.js",
     "lint": "eslint . --ext .js,.vue --fix"
   },
   "dependencies": {

--- a/examples/vue-hydration/package.json
+++ b/examples/vue-hydration/package.json
@@ -1,8 +1,8 @@
 {
   "type": "module",
   "scripts": {
-    "dev": "node server --dev",
-    "devinstall": "zx ../../devinstall.mjs vue-vanilla -- node server --dev",
+    "dev": "node server.js --dev",
+    "devinstall": "zx ../../devinstall.mjs vue-vanilla -- node server.js --dev",
     "build": "npm run build:client && npm run build:server",
     "build:client": "vite build --outDir dist/client --ssrManifest",
     "build:server": "vite build --outDir dist/server --ssr /index.js",

--- a/examples/vue-hydration/package.json
+++ b/examples/vue-hydration/package.json
@@ -1,8 +1,8 @@
 {
   "type": "module",
   "scripts": {
-    "dev": "node ./server --dev",
-    "devinstall": "zx ../../devinstall.mjs vue-vanilla -- node ./server --dev",
+    "dev": "node server --dev",
+    "devinstall": "zx ../../devinstall.mjs vue-vanilla -- node server --dev",
     "build": "npm run build:client && npm run build:server",
     "build:client": "vite build --outDir dist/client --ssrManifest",
     "build:server": "vite build --outDir dist/server --ssr /index.js",

--- a/examples/vue-hydration/vite.config.js
+++ b/examples/vue-hydration/vite.config.js
@@ -1,11 +1,10 @@
-import { join, dirname } from 'path'
 import viteVue from '@vitejs/plugin-vue'
 // import viteVueJsx from '@vitejs/plugin-vue-jsx'
 import viteFastify from 'fastify-vite/plugin'
 
 // @type {import('vite').UserConfig}
 export default {
-  root: join(dirname(new URL(import.meta.url).pathname), 'client'),
+  root: './client',
   plugins: [
     viteVue(),
     // viteVueJsx(),

--- a/examples/vue-next/package.json
+++ b/examples/vue-next/package.json
@@ -1,8 +1,8 @@
 {
   "type": "module",
   "scripts": {
-    "dev": "node server.js --dev",
-    "devinstall": "zx ../../devinstall.mjs vue-next -- node server.js --dev",
+    "dev": "node ./server.js --dev",
+    "devinstall": "zx ../../devinstall.mjs vue-next -- node ./server.js --dev",
     "build": "npm run build:client && npm run build:server",
     "build:client": "vite build --outDir dist/client --ssrManifest",
     "build:server": "vite build --outDir dist/server --ssr /index.js",

--- a/examples/vue-next/package.json
+++ b/examples/vue-next/package.json
@@ -1,8 +1,8 @@
 {
   "type": "module",
   "scripts": {
-    "dev": "node ./server.js --dev",
-    "devinstall": "zx ../../devinstall.mjs vue-next -- node ./server.js --dev",
+    "dev": "node server.js --dev",
+    "devinstall": "zx ../../devinstall.mjs vue-next -- node server.js --dev",
     "build": "npm run build:client && npm run build:server",
     "build:client": "vite build --outDir dist/client --ssrManifest",
     "build:server": "vite build --outDir dist/server --ssr /index.js",

--- a/examples/vue-next/package.json
+++ b/examples/vue-next/package.json
@@ -5,7 +5,7 @@
     "devinstall": "zx ../../devinstall.mjs vue-next -- node server.js --dev",
     "build": "npm run build:client && npm run build:server",
     "build:client": "vite build --outDir dist/client --ssrManifest",
-    "build:server": "vite build --outDir dist/server --ssr /index.js",
+    "build:server": "vite build --outDir dist/server --ssr ./index.js",
     "lint": "eslint . --ext .js,.vue --fix"
   },
   "dependencies": {

--- a/examples/vue-next/vite.config.js
+++ b/examples/vue-next/vite.config.js
@@ -1,11 +1,10 @@
-import { join, dirname } from 'path'
 import viteVue from '@vitejs/plugin-vue'
 // import viteVueJsx from '@vitejs/plugin-vue-jsx'
 import viteFastify from 'fastify-vite/plugin'
 
 // @type {import('vite').UserConfig}
 export default {
-  root: join(dirname(new URL(import.meta.url).pathname), 'client'),
+  root: './client',
   plugins: [
     viteVue(),
     // viteVueJsx(),

--- a/examples/vue-streaming/package.json
+++ b/examples/vue-streaming/package.json
@@ -5,7 +5,7 @@
     "devinstall": "zx ../../devinstall.mjs vue-vanilla -- node server.js --dev",
     "build": "npm run build:client && npm run build:server",
     "build:client": "vite build --outDir dist/client --ssrManifest",
-    "build:server": "vite build --outDir dist/server --ssr /index.js",
+    "build:server": "vite build --outDir dist/server --ssr ./index.js",
     "lint": "eslint . --ext .js,.vue --fix"
   },
   "dependencies": {

--- a/examples/vue-streaming/package.json
+++ b/examples/vue-streaming/package.json
@@ -1,12 +1,12 @@
 {
   "type": "module",
   "scripts": {
-    "dev": "node server.js --dev",
-    "devinstall": "zx ../../devinstall.mjs vue-vanilla -- node server.js --dev",
+    "dev": "node ./server.js --dev",
+    "devinstall": "zx ../../devinstall.mjs vue-vanilla -- node ./server.js --dev",
     "build": "npm run build:client && npm run build:server",
     "build:client": "vite build --outDir dist/client --ssrManifest",
     "build:server": "vite build --outDir dist/server --ssr /index.js",
-    "lint": "eslint . --ext .js,.vue --fix",
+    "lint": "eslint . --ext .js,.vue --fix"
   },
   "dependencies": {
     "fastify-vite": "3.0.0-beta.21",

--- a/examples/vue-streaming/package.json
+++ b/examples/vue-streaming/package.json
@@ -1,8 +1,8 @@
 {
   "type": "module",
   "scripts": {
-    "dev": "node ./server.js --dev",
-    "devinstall": "zx ../../devinstall.mjs vue-vanilla -- node ./server.js --dev",
+    "dev": "node server.js --dev",
+    "devinstall": "zx ../../devinstall.mjs vue-vanilla -- node server.js --dev",
     "build": "npm run build:client && npm run build:server",
     "build:client": "vite build --outDir dist/client --ssrManifest",
     "build:server": "vite build --outDir dist/server --ssr /index.js",

--- a/examples/vue-streaming/vite.config.js
+++ b/examples/vue-streaming/vite.config.js
@@ -1,11 +1,10 @@
-import { join, dirname } from 'path'
 import viteVue from '@vitejs/plugin-vue'
 // import viteVueJsx from '@vitejs/plugin-vue-jsx'
 import viteFastify from 'fastify-vite/plugin'
 
 // @type {import('vite').UserConfig}
 export default {
-  root: join(dirname(new URL(import.meta.url).pathname), 'client'),
+  root: './client',
   plugins: [
     viteVue(),
     // viteVueJsx(),

--- a/examples/vue-vanilla/package.json
+++ b/examples/vue-vanilla/package.json
@@ -1,8 +1,8 @@
 {
   "type": "module",
   "scripts": {
-    "dev": "node server.js --dev",
-    "devinstall": "zx ../../devinstall.mjs vue-vanilla -- node server.js --dev",
+    "dev": "node ./server --dev",
+    "devinstall": "zx ../../devinstall.mjs vue-vanilla -- node ./server --dev",
     "build": "npm run build:client && npm run build:server",
     "build:client": "vite build --outDir dist/client --ssrManifest",
     "build:server": "vite build --outDir dist/server --ssr /index.js",

--- a/examples/vue-vanilla/package.json
+++ b/examples/vue-vanilla/package.json
@@ -5,7 +5,7 @@
     "devinstall": "zx ../../devinstall.mjs vue-vanilla -- node server.js --dev",
     "build": "npm run build:client && npm run build:server",
     "build:client": "vite build --outDir dist/client --ssrManifest",
-    "build:server": "vite build --outDir dist/server --ssr /index.js",
+    "build:server": "vite build --outDir dist/server --ssr ./index.js",
     "lint": "eslint . --ext .js,.vue --fix"
   },
   "dependencies": {

--- a/examples/vue-vanilla/package.json
+++ b/examples/vue-vanilla/package.json
@@ -1,8 +1,8 @@
 {
   "type": "module",
   "scripts": {
-    "dev": "node server --dev",
-    "devinstall": "zx ../../devinstall.mjs vue-vanilla -- node server --dev",
+    "dev": "node server.js --dev",
+    "devinstall": "zx ../../devinstall.mjs vue-vanilla -- node server.js --dev",
     "build": "npm run build:client && npm run build:server",
     "build:client": "vite build --outDir dist/client --ssrManifest",
     "build:server": "vite build --outDir dist/server --ssr /index.js",

--- a/examples/vue-vanilla/package.json
+++ b/examples/vue-vanilla/package.json
@@ -1,8 +1,8 @@
 {
   "type": "module",
   "scripts": {
-    "dev": "node ./server --dev",
-    "devinstall": "zx ../../devinstall.mjs vue-vanilla -- node ./server --dev",
+    "dev": "node server --dev",
+    "devinstall": "zx ../../devinstall.mjs vue-vanilla -- node server --dev",
     "build": "npm run build:client && npm run build:server",
     "build:client": "vite build --outDir dist/client --ssrManifest",
     "build:server": "vite build --outDir dist/server --ssr /index.js",

--- a/examples/vue-vanilla/vite.config.js
+++ b/examples/vue-vanilla/vite.config.js
@@ -1,11 +1,10 @@
-import { join, dirname } from 'path'
 import viteVue from '@vitejs/plugin-vue'
 // import viteVueJsx from '@vitejs/plugin-vue-jsx'
 import viteFastify from 'fastify-vite/plugin'
 
 // @type {import('vite').UserConfig}
 export default {
-  root: join(dirname(new URL(import.meta.url).pathname), 'client'),
+  root: './client',
   plugins: [
     viteVue(),
     // viteVueJsx(),

--- a/packages/fastify-vite/mode/production.js
+++ b/packages/fastify-vite/mode/production.js
@@ -10,10 +10,10 @@ function fileUrl (str) {
 
   // Windows drive letter must be prefixed with a slash
   if (pathName[0] !== '/') {
-    pathName = `/${pathName}`;
+    pathName = `/${pathName}`
   }
 
-  return encodeURI(`file://${pathName}`);
+  return encodeURI(`file://${pathName}`)
 }
 
 async function setup (config) {

--- a/packages/fastify-vite/mode/production.js
+++ b/packages/fastify-vite/mode/production.js
@@ -1,19 +1,19 @@
 const { resolve, join, exists, basename } = require('../ioutils')
 const FastifyStatic = require('@fastify/static')
 
-function fileUrl(str) {
-  if (typeof str !== "string") {
-    throw new Error("Expected a string");
+function fileUrl (str) {
+  if (typeof str !== 'string') {
+    throw new Error('Expected a string')
   }
 
-  let pathName = resolve(str).replace(/\\/g, "/");
+  let pathName = resolve(str).replace(/\\/g, '/')
 
   // Windows drive letter must be prefixed with a slash
-  if (pathName[0] !== "/") {
-    pathName = "/" + pathName;
+  if (pathName[0] !== '/') {
+    pathName = `/${pathName}`;
   }
 
-  return encodeURI("file://" + pathName);
+  return encodeURI(`file://${pathName}`);
 }
 
 async function setup (config) {
@@ -65,12 +65,11 @@ async function setup (config) {
   // Loads the Vite application server entry point for the client
   async function loadClient () {
     const serverFile = join('server', basename(config.clientModule))
-    // on windows use file path
-    const serverBundlePath =
-        process.platform === "win32"
-            ? fileUrl(resolve(config.bundle.dir, serverFile))
-            : resolve(config.bundle.dir, serverFile);
-    const serverBundle = await import(serverBundlePath);
+    // Use file path on Windows
+    const serverBundlePath = process.platform === 'win32'
+      ? fileUrl(resolve(config.bundle.dir, serverFile))
+      : resolve(config.bundle.dir, serverFile)
+    const serverBundle = await import(serverBundlePath)
     return serverBundle.default ?? serverBundle
   }
 }


### PR DESCRIPTION
These changes are for better windows file system support. 

I changed the build:server script to use "./index.js" as opposed to "/index.js"

I changed the root in the vite.config.js in the example projects to use the relative file path "./client" as windows and *nix systems file paths are different.

I changed the production file to check if it's windows and use the file path instead of the file url if it is. Windows esm loader requires file path. 