### PR TITLE
fix: add windows file check for import in config

### DIFF
--- a/packages/fastify-vite/config.js
+++ b/packages/fastify-vite/config.js
@@ -157,11 +157,14 @@ function resolveRoot (root) {
 
 async function resolveViteConfig (root, dev) {
   for (const ext of ['js', 'mjs', 'ts']) {
-    const configFile = join(root, `vite.config.${ext}`)
+    let configFile = join(root, `vite.config.${ext}`)
     if (exists(configFile)) {
       const resolvedConfig = await resolveConfig({
         configFile,
       }, 'serve', dev ? 'development' : 'production')
+      if (process.platform === 'win32') {
+        configFile = `file://${configFile}`
+      }
       let userConfig = await import(configFile).then(m => m.default)
       if (userConfig.default) {
         userConfig = userConfig.default


### PR DESCRIPTION
This pr solves an issue with loading the vite config in windows

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
