### PR TITLE
fix: unable to find server bundle on Windows

### DIFF
--- a/packages/fastify-vite/mode/production.js
+++ b/packages/fastify-vite/mode/production.js
@@ -84,7 +84,7 @@ async function setup (config) {
     for (const serverFile of serverFiles) {
       // Use file path on Windows
       serverBundlePath = process.platform === 'win32'
-        ? fileUrl(resolve(config.bundle.dir, serverFile))
+        ? new URL(fileUrl(resolve(config.bundle.dir, serverFile)))
         : resolve(config.bundle.dir, serverFile)
       if (await exists(serverBundlePath)) {
         break


### PR DESCRIPTION
On Windows system `await exists(serverBundlePath)` is never satisfied when file path is file URL. When converted to URL it works as expected.