### PR TITLE
Update `SolidJS` examples

### DIFF
--- a/examples/solid-hydration/client/base.jsx
+++ b/examples/solid-hydration/client/base.jsx
@@ -1,5 +1,5 @@
+import { Router, Routes, Route } from '@solidjs/router'
 import { createContext, useContext, createSignal } from 'solid-js'
-import { Router, Routes, Route } from 'solid-app-router'
 import routes from './routes.js'
 
 export function createApp (props) {

--- a/examples/solid-hydration/client/views/index.jsx
+++ b/examples/solid-hydration/client/views/index.jsx
@@ -1,5 +1,5 @@
+import { Link } from '@solidjs/router'
 import { For } from 'solid-js'
-import { Link } from 'solid-app-router'
 
 export default function Index (props) {
   let input

--- a/examples/solid-hydration/client/views/other.jsx
+++ b/examples/solid-hydration/client/views/other.jsx
@@ -1,4 +1,4 @@
-import { Link } from 'solid-app-router'
+import { Link } from '@solidjs/router'
 
 export default function Other () {
   return (

--- a/examples/solid-hydration/package.json
+++ b/examples/solid-hydration/package.json
@@ -10,32 +10,33 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "devalue": "^2.0.1",
-    "solid-app-router": "^0.3.3",
-    "fastify": "^4.7.0",
-    "vite": "^3.1.6",
-    "@fastify/static": "^6.5.0",
-    "fs-extra": "^10.0.0",
-    "klaw": "^4.0.1",
-    "middie": "^5.2.0"
+    "@fastify/vite": "^3.0.8",
+    "@solidjs/router": "^0.7.0",
+    "devalue": "^4.2.3",
+    "fastify": "^4.13.0",
+    "solid-js": "^1.6.10",
+    "vite": "^4.1.1",
+    "vite-plugin-solid": "^2.5.0"
   },
   "devDependencies": {
-    "@babel/eslint-parser": "^7.16.0",
-    "eslint": "^7.32.0",
-    "eslint-config-standard": "^16.0.2",
-    "eslint-plugin-import": "^2.22.1",
+    "@babel/core": "^7.20.12",
+    "@babel/eslint-parser": "^7.19.1",
+    "eslint": "^8.33.0",
+    "eslint-config-standard": "^17.0.0",
+    "eslint-plugin-import": "^2.27.5",
+    "eslint-plugin-n": "^15.6.1",
     "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-promise": "^4.3.1",
-    "eslint-plugin-solid": "^0.4.7",
-    "vite-plugin-solid": "^2.2.6"
+    "eslint-plugin-promise": "^6.1.1",
+    "eslint-plugin-solid": "^0.9.4",
+    "vitest": "^0.28.4"
   },
   "devInstall": {
     "local": {
-      "@fastify/vite": "^3.0.1"
+      "@fastify/vite": "^3.0.8"
     },
     "external": {
-      "devalue": "^2.0.1",
-      "solid-app-router": "^0.3.3"
+      "@solidjs/router": "^0.7.0",
+      "devalue": "^4.2.3"
     }
   }
 }

--- a/examples/solid-hydration/renderer.js
+++ b/examples/solid-hydration/renderer.js
@@ -2,12 +2,10 @@ import { renderToStringAsync, generateHydrationScript } from 'solid-js/web'
 
 // Used to safely serialize JavaScript into
 // <script> tags, preventing a few types of attack
-import devalue from 'devalue'
+import { uneval } from 'devalue'
 
 // The @fastify/vite renderer overrides
-export default { createRenderFunction }
-
-function createRenderFunction ({ createApp }) {
+export function createRenderFunction ({ createApp }) {
   // createApp is exported by client/index.js
   return async function (server, req, reply) {
     // Server data that we want to be used for SSR
@@ -27,7 +25,7 @@ function createRenderFunction ({ createApp }) {
       // Server-side rendered HTML fragment
       element,
       // The SSR context data is also passed to the template, inlined for hydration
-      hydration: `<script>window.hydration = ${devalue({ data })}</script>`,
+      hydration: `<script>window.hydration = ${uneval({ data })}</script>`,
       // Required by Solid
       hydrationScript: generateHydrationScript()
     }

--- a/examples/solid-hydration/server.js
+++ b/examples/solid-hydration/server.js
@@ -1,6 +1,7 @@
 import Fastify from 'fastify'
 import FastifyVite from '@fastify/vite'
-import renderer from './renderer.js'
+import { join } from 'node:path'
+import { createRenderFunction } from './renderer.js'
 
 export async function main (dev) {
   const server = Fastify()
@@ -8,7 +9,7 @@ export async function main (dev) {
   await server.register(FastifyVite, {
     root: import.meta.url,
     dev: dev || process.argv.includes('--dev'),
-    renderer
+    createRenderFunction
   })
 
   await server.vite.ready()
@@ -16,7 +17,7 @@ export async function main (dev) {
   return server
 }
 
-if (process.argv[1] === new URL(import.meta.url).pathname) {
+if (process.argv[1] === join(process.cwd(), 'server.js')) {
   const server = await main()
   await server.listen({ port: 3000 })
 }

--- a/examples/solid-hydration/vite.config.js
+++ b/examples/solid-hydration/vite.config.js
@@ -1,15 +1,14 @@
-import { resolve, dirname } from 'path'
+import { join } from 'node:path'
 import viteSolid from 'vite-plugin-solid'
 
-const path = new URL(import.meta.url).pathname
-const root = resolve(dirname(path), 'client')
+const root = join(process.cwd(), 'client')
 
 const plugins = [
   viteSolid({ ssr: true }),
 ]
 
 const ssr = {
-  noExternal: ['solid-app-router'],
+  noExternal: ['@solidjs/router'],
 }
 
 export default {

--- a/examples/solid-hydration/vitest.config.js
+++ b/examples/solid-hydration/vitest.config.js
@@ -1,8 +1,7 @@
-import { dirname } from 'node:path'
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
-  root: dirname(new URL(import.meta.url).pathname),
+  root: process.cwd(),
   test: {
     testTimeout: 15000,
   }

--- a/examples/solid-vanilla/client/mount.js
+++ b/examples/solid-vanilla/client/mount.js
@@ -3,5 +3,5 @@ import { createApp } from './base.jsx'
 
 hydrate(
   createApp(),
-  document.querySelector('main'),  
+  document.querySelector('main')
 )

--- a/examples/solid-vanilla/package.json
+++ b/examples/solid-vanilla/package.json
@@ -10,30 +10,30 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "solid-js": "^1.4.2",
-    "fastify": "^4.7.0",
-    "vite": "^3.1.6",
-    "@fastify/static": "^6.5.0",
-    "fs-extra": "^10.0.0",
-    "klaw": "^4.0.1",
-    "middie": "^5.2.0"
+    "@fastify/vite": "^3.0.8",
+    "fastify": "^4.13.0",
+    "solid-js": "^1.6.10",
+    "vite": "^4.1.1",
+    "vite-plugin-solid": "^2.5.0"
   },
   "devDependencies": {
-    "@babel/eslint-parser": "^7.16.0",
-    "eslint": "^7.32.0",
-    "eslint-config-standard": "^16.0.2",
-    "eslint-plugin-import": "^2.22.1",
+    "@babel/core": "^7.20.12",
+    "@babel/eslint-parser": "^7.19.1",
+    "eslint": "^8.33.0",
+    "eslint-config-standard": "^17.0.0",
+    "eslint-plugin-import": "^2.27.5",
+    "eslint-plugin-n": "^15.6.1",
     "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-promise": "^4.3.1",
-    "eslint-plugin-solid": "^0.4.7",
-    "vite-plugin-solid": "^2.2.6"
+    "eslint-plugin-promise": "^6.1.1",
+    "eslint-plugin-solid": "^0.9.4",
+    "vitest": "^0.28.4"
   },
   "devInstall": {
     "local": {
-      "@fastify/vite": "^3.0.1"
+      "@fastify/vite": "^3.0.8"
     },
     "external": {
-      "solid-js": "^1.4.2"
+      "solid-js": "^1.6.10"
     }
   }
 }

--- a/examples/solid-vanilla/server.js
+++ b/examples/solid-vanilla/server.js
@@ -1,31 +1,32 @@
 import Fastify from 'fastify'
 import FastifyVite from '@fastify/vite'
+import { join } from 'node:path'
 import { renderToStringAsync } from 'solid-js/web'
 
 export async function main (dev) {
   const server = Fastify()
-  
-  await server.register(FastifyVite, { 
-    root: import.meta.url, 
+
+  await server.register(FastifyVite, {
+    root: import.meta.url,
     dev: dev || process.argv.includes('--dev'),
     createRenderFunction ({ createApp }) {
       return async () => {
         return {
-          element: await renderToStringAsync(createApp())
+          element: await renderToStringAsync(createApp()),
         }
       }
     }
   })
-  
+
   server.get('/', async (req, reply) => {
     reply.html(await reply.render())
   })
-  
+
   await server.vite.ready()
   return server
 }
 
-if (process.argv[1] === new URL(import.meta.url).pathname) {
+if (process.argv[1] === join(process.cwd(), 'server.js')) {
   const server = await main()
   await server.listen({ port: 3000 })
 }

--- a/examples/solid-vanilla/server.test.js
+++ b/examples/solid-vanilla/server.test.js
@@ -1,7 +1,7 @@
 import { join, resolve, dirname } from 'node:path'
 import { beforeAll, afterAll, assert, expect, test } from 'vitest'
 import { makeSSRBuildTest, makeIndexTest } from '../../testing.js'
-import { main } from './server.js' 
+import { main } from './server.js'
 
 const cwd = dirname(new URL(import.meta.url).pathname)
 

--- a/examples/solid-vanilla/vite.config.js
+++ b/examples/solid-vanilla/vite.config.js
@@ -1,8 +1,7 @@
-import { resolve, dirname } from 'path'
+import { join } from 'node:path'
 import viteSolid from 'vite-plugin-solid'
 
-const path = new URL(import.meta.url).pathname
-const root = resolve(dirname(path), 'client')
+const root = join(process.cwd(), 'client')
 
 const plugins = [
   viteSolid({ ssr: true }),

--- a/examples/solid-vanilla/vitest.config.js
+++ b/examples/solid-vanilla/vitest.config.js
@@ -1,8 +1,7 @@
-import { dirname } from 'node:path'
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
-  root: dirname(new URL(import.meta.url).pathname),
+  root: process.cwd(),
   test: {
     testTimeout: 15000,
   }


### PR DESCRIPTION
Update `solid-js` examples:
- [solid-hydration](https://github.com/fastify/fastify-vite/tree/dev/examples/solid-hydration)
- [solid-vanilla](https://github.com/fastify/fastify-vite/tree/dev/examples/solid-vanilla)

### Details:
- Update _dependencies_ and _devDependencies_
- Dependencies:
  - Added `@fastify/vite`, `solid-js`
  - Removed deprecated `solid-app-router` with `@solidjs/router`
  - Removed `@fastify/static`, `fs-extra`, `klaw` because they are already included in `@fastify/vite`
  - Added `vite-plugin-solid` (removed from dev dependencies)
- Dev dependencies:
  - Added `vitest`
  - Added `eslint-plugin-n` peer dependencies of `eslint-config-standard`
  - Added `@babel/core` peer dependencies of `@babel/eslint-parser`
- Windows compatibility:
  - Replaced `new URL(import.meta.url).pathname` with `process.cwd()`
- solid-hydration example:
  - Replaced `renderer` with `createRenderFunction` in _server.js_ (TypeError: config.createRenderFunction is not a function)

### Open points:
- [ ] On both examples, there is a console warning in browser:
  - > computations created outside a `createRoot` or `render` will never be disposed`