### PR TITLE
fix(hmr): fix hmr when using h2 and use merge config

### DIFF
--- a/packages/fastify-vite/mode/development.js
+++ b/packages/fastify-vite/mode/development.js
@@ -9,7 +9,6 @@ async function setup (config) {
 
   // Create and enable Vite's Dev Server middleware
   const devServerOptions = mergeConfig(
-    config.vite,
     defineConfig({
       configFile: false,
       server: {
@@ -19,7 +18,8 @@ async function setup (config) {
         }
       },
       appType: 'custom'
-    })
+    }),
+    config.vite
   )
 
   const { createServer } = require('vite')

--- a/packages/fastify-vite/mode/development.js
+++ b/packages/fastify-vite/mode/development.js
@@ -1,4 +1,5 @@
 const middie = require('@fastify/middie')
+const { mergeConfig, defineConfig } = require('vite')
 const { join, resolve, read } = require('../ioutils')
 
 async function setup (config) {
@@ -7,15 +8,20 @@ async function setup (config) {
   await this.scope.register(middie)
 
   // Create and enable Vite's Dev Server middleware
-  const devServerOptions = {
-    configFile: false,
-    ...config.vite,
-    server: {
-      middlewareMode: true,
-      ...config.vite.server
-    },
-    appType: 'custom'
-  }
+  const devServerOptions = mergeConfig(
+    config.vite,
+    defineConfig({
+      configFile: false,
+      server: {
+        middlewareMode: true,
+        hmr: {
+          server: this.scope.server
+        }
+      },
+      appType: 'custom'
+    })
+  )
+
   const { createServer } = require('vite')
   this.devServer = await createServer(devServerOptions)
   this.scope.use(this.devServer.middlewares)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Description

[Sets vite hmr server to use fastify.](https://vitejs.dev/config/server-options.html#server-hmr:~:text=When%20server.hmr,a%20single%20port.) This fixes #109 and will allow users to use https and h2 with @fastify/vite. Also uses `mergeConfig` and `defineConfig` for hassle free recursive config merging and type safe config declarations.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
