### PR TITLE
docs: fix react references in documentation

### DIFF
--- a/docs/react/index.md
+++ b/docs/react/index.md
@@ -2,7 +2,7 @@
 
 # Getting Started
 
-**`@fastify/react`** is **@fastify/vite**'s [**core renderer**](/guide/core-renderers) for [Vue][vue]. It is accompanied by **`@fastify/react/plugin`**, a Vite plugin that complements the renderer package.
+**`@fastify/react`** is **@fastify/vite**'s [**core renderer**](/guide/core-renderers) for [React][react]. It is accompanied by **`@fastify/react/plugin`**, a Vite plugin that complements the renderer package.
 
 It implements all of the features specified in [**Core Renderers**](/guide/core-renderers), including [**automated routing**](/react/router-setup), [**universal data fetching**](/react/route-modules#data-fetching) and [**head management**](/react/route-modules#page-metadata). It's meant to be a lightweight Fastify-flavored replacement to **Next.js** and other full blown SSR React frameworks. It is **Fastify-first** in the sense that your Fastify server is responsible for setting everything up via **`@fastify/vite`**.
 
@@ -10,7 +10,7 @@ Below is an overview of all individual documentation topics and the order in whi
 
 - [Project Structure](/react/project-structure) covers the structure of a **`@fastify/react`** project, configuration, special folders and others conventions employed.
 - [Router Setup](/react/router-setup) covers how route modules get registered as actual routes, both on the server and the client.
-- [Route Modules](/react/route-modules) covers what makes up route modules, what special exports they have and how they work. 
+- [Route Modules](/react/route-modules) covers what makes up route modules, what special exports they have and how they work.
 - [Route Context](/react/route-context) covers the universal **route context** initialization module and the `useRouteContext()` hook, available to all route modules and route layouts.
 - [Route Layouts](/react/route-layouts) covers **route layout modules**.
 - [Rendering Modes](/react/rendering-modes) covers all different route module **rendering modes**.


### PR DESCRIPTION
This pr fixes the references to React in the documentation. The previous references for `@fastify/react` were incorrect and pointing to Vue.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
