### PR TITLE
fix: explicitly export named type

### DIFF
--- a/packages/fastify-vite/index.js
+++ b/packages/fastify-vite/index.js
@@ -36,11 +36,15 @@ class Vite {
   }
 }
 
-function fastifyVite (scope, options, done) {
+function plugin (scope, options, done) {
   scope.decorate('vite', new Vite(scope, options))
   done()
 }
 
-module.exports = fp(fastifyVite, {
+const fastifyVite = fp(plugin, {
   name: '@fastify/vite'
 })
+
+module.exports = fastifyVite
+module.exports.default = fastifyVite
+module.exports.fastifyVite = fastifyVite


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Description

There is no named export for the plugin, encountered this when trying to dynamically import the plugin into an ESM file. This change copies the export style of [`@fastify/cookie`](https://github.com/fastify/fastify-cookie/blob/master/plugin.js#L203). I presume that this was not caught by tests because something (Vitest? Node?) is helping with CJS compatibility that masks the problem when running tests.

I have not included tests for this for two reasons, first because it does not seem to be tested for in various other Fastify packages and secondly because the test I produced feels very hacky. I have included it below.

`index.test.mjs`
```js
import { expect, test } from 'vitest'

test('esm - should import plugin dynamically with default and named', async () => {
  const FastifyVite = await import('./index.js')
  expect(FastifyVite.default).toBeDefined()
  expect(FastifyVite.fastifyVite).toBeDefined()
})
```

`vitest.config.js`
```js
import { defineConfig } from 'vitest/config'

export default defineConfig({
  root: process.cwd(),
  base: process.cwd(),
  test: {
    threads: false,
    deps: {
      interopDefault: false,
      moduleDirectories: ['.']
    }
  }
})
```

Needing two flags to recreate this phenomenon and the potential side effects that may cause is why I'm on the side of caution and haven't included a test for this. The cost might outweigh the benefits.


#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
