### PR TITLE
revert(fastify-vite): fix(fastify-vite): file path formats on Windows…

### DIFF
--- a/packages/fastify-vite/config.js
+++ b/packages/fastify-vite/config.js
@@ -186,7 +186,7 @@ function resolveClientModule(root) {
 function resolveRoot(path) {
   let root = path
   if (root.startsWith('file:')) {
-    root = fileURLToPath(root).replace(/^file:\/\/\/([A-Z]):\//, 'file:///$1|/')
+    root = fileURLToPath(root)
   }
   if (stat(root).isFile()) {
     return dirname(root)
@@ -209,10 +209,7 @@ async function resolveViteConfig(root, dev, isSpa) {
         mode,
       )
       if (process.platform === 'win32') {
-        configFile = `file://${configFile}`.replace(
-          /^file:\/\/\/([A-Z]):\//,
-          'file:///$1|/',
-        )
+        configFile = `file://${configFile}`
       }
       let userConfig = await import(configFile).then((m) => m.default)
       if (userConfig.default) {

--- a/packages/fastify-vite/mode/production.js
+++ b/packages/fastify-vite/mode/production.js
@@ -115,12 +115,7 @@ async function setup(config) {
     )
     const ssrManifest =
       process.platform === 'win32'
-        ? new URL(
-            fileUrl(ssrManifestPath).replace(
-              /^file:\/\/\/([A-Z]):\//,
-              'file:///$1|/',
-            ),
-          )
+        ? new URL(fileUrl(ssrManifestPath))
         : ssrManifestPath
     const serverFiles = [
       join('server', `${parse(config.clientModule).name}.js`),
@@ -131,12 +126,7 @@ async function setup(config) {
       // Use file path on Windows
       serverBundlePath =
         process.platform === 'win32'
-          ? new URL(
-              fileUrl(resolve(config.bundle.dir, serverFile)).replace(
-                /^file:\/\/\/([A-Z]):\//,
-                'file:///$1|/',
-              ),
-            )
+          ? new URL(fileUrl(resolve(config.bundle.dir, serverFile)))
           : resolve(config.bundle.dir, serverFile)
       if (await exists(serverBundlePath)) {
         break


### PR DESCRIPTION
… (#138)

### Description

The issue arises from the injected path. 

https://github.com/fastify/fastify-vite/blob/dev/packages/fastify-react/virtual/routes.js#L5
https://github.com/fastify/fastify-vite/blob/dev/packages/fastify-react/virtual/routes.js#L5

My bad. At that time, I made some changes to the path, and the execution seemed feasible.

I'm attempting to avoid using `root: join(dirname(path), 'client'),`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
