### PR TITLE
chore: add LICENSE to repo and fill out missing package.json keys

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021-present Jonas Galvez
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/fastify-htmx/package.json
+++ b/packages/fastify-htmx/package.json
@@ -33,5 +33,18 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^1.5.3"
-  }
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/fastify/fastify-vite.git"
+  },
+  "keywords": [
+    "fastify",
+    "vite",
+    "htmx"
+  ],
+  "bugs": {
+    "url": "https://github.com/fastify/fastify-vite/issues"
+  },
+  "homepage": "https://github.com/fastify/fastify-vite#readme"
 }

--- a/packages/fastify-react/package.json
+++ b/packages/fastify-react/package.json
@@ -45,5 +45,18 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/fastify/fastify-vite.git"
+  },
+  "keywords": [
+    "fastify",
+    "vite",
+    "react"
+  ],
+  "bugs": {
+    "url": "https://github.com/fastify/fastify-vite/issues"
+  },
+  "homepage": "https://fastify-vite.dev/react/"
 }

--- a/packages/fastify-vite/package.json
+++ b/packages/fastify-vite/package.json
@@ -31,7 +31,7 @@
     },
     "./utils": "./utils.js"
   },
-  "homepage": "https://github.com/fastify/fastify-vite",
+  "homepage": "https://fastify-vite.dev/",
   "license": "MIT",
   "main": "index.js",
   "name": "@fastify/vite",
@@ -60,5 +60,9 @@
     "fastify": "^4.26.1",
     "typescript": "^5.3.3",
     "vitest": "^1.3.0"
-  }
+  },
+  "keywords": [
+    "fastify",
+    "vite"
+  ]
 }

--- a/packages/fastify-vue/package.json
+++ b/packages/fastify-vue/package.json
@@ -45,5 +45,18 @@
   },
   "scripts": {
     "lint": "eslint . --ext .js,.vue --fix"
-  }
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/fastify/fastify-vite.git"
+  },
+  "keywords": [
+    "fastify",
+    "vite",
+    "vue"
+  ],
+  "bugs": {
+    "url": "https://github.com/fastify/fastify-vite/issues"
+  },
+  "homepage": "https://fastify-vite.dev/vue/"
 }


### PR DESCRIPTION
I added repository, keywords, bugs and homepage to package.json files that were missing them for discoverability and better DX.

I added a license file to the root of the repo, so it can be discovered by GitHub. For the copyright statement I was going to include the Fastify Team, but the docs very strongly emphasize that Jonas Galvez is the only maintainer. This matches the copyright statement on the website.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
