### PR TITLE
test: Add unit tests for createHtmlTemplateFunction

### DIFF
--- a/packages/fastify-vite/html.test.js
+++ b/packages/fastify-vite/html.test.js
@@ -1,0 +1,50 @@
+import { readFile } from 'node:fs/promises';
+import { describe, expect, test } from 'vitest'
+import { createHtmlTemplateFunction } from './html.js';
+
+describe('createHtmlTemplateFunction', () => {
+	test('replaces comments without spaces <!-- element -->', async () => {
+		const templateFn = createHtmlTemplateFunction([
+			'<!doctype html>',
+			'<!-- element -->',
+			'<script type="module" src="./mount.js"></script>',
+		].join('\n'));
+		const resultStream = templateFn({ element: 'walalalala' });
+		const resultStr = await streamToString(resultStream);
+
+		expect(resultStr).toBe([
+			'<!doctype html>',
+			'walalalala',
+			'<script type="module" src="./mount.js"></script>',
+		].join('\n'));
+	});
+
+	test('leaves comments with spaces alone', async () => {
+		const templateFn = createHtmlTemplateFunction([
+			'<!-- arbitrary comment -->',
+			'<!doctype html>',
+			'<!-- detailed explanation here -->',
+			'<script type="module" src="./mount.js"></script>',
+			'<!-- secret easter egg note -->',
+		].join('\n'));
+		const resultStream = templateFn({ element: '' });
+		const resultStr = await streamToString(resultStream);
+
+		expect(resultStr).toBe([
+			'<!-- arbitrary comment -->',
+			'<!doctype html>',
+			'<!-- detailed explanation here -->',
+			'<script type="module" src="./mount.js"></script>',
+			'<!-- secret easter egg note -->',
+		].join('\n'));
+	});
+
+	function streamToString(stream) {
+		const chunks = [];
+		return new Promise((resolve, reject) => {
+			stream.on('data', (chunk) => chunks.push(Buffer.from(chunk)));
+			stream.on('error', (err) => reject(err));
+			stream.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+		})
+	}
+});


### PR DESCRIPTION
This PR is testing to see if making PRs from my fork repo (rather than another branch in this repo) passes the `agitated-mahavira` CI checks.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
