### PR TITLE
Convert sharedPaths.cjs to .mjs in order to use latest find-cache-dir

### DIFF
--- a/packages/fastify-vite/config.js
+++ b/packages/fastify-vite/config.js
@@ -9,7 +9,6 @@ const {
   read,
 } = require('./ioutils.cjs')
 const { createHtmlTemplateFunction } = require('./html.js')
-const { CACHE_DIR, CACHED_VITE_CONFIG_FILE_NAME } = require('./sharedPaths.cjs')
 
 const DefaultConfig = {
   // Whether or not to enable Vite's Dev Server
@@ -208,6 +207,7 @@ async function resolveViteConfig(root, dev, { spa } = {}) {
   const mode = dev ? 'development' : 'production'
 
   if (!dev) {
+    const { CACHE_DIR, CACHED_VITE_CONFIG_FILE_NAME } = await import('./sharedPaths.mjs')
     const viteConfigDistFile = resolve(CACHE_DIR, CACHED_VITE_CONFIG_FILE_NAME)
 
     if (exists(viteConfigDistFile)) {

--- a/packages/fastify-vite/package.json
+++ b/packages/fastify-vite/package.json
@@ -18,7 +18,7 @@
     "mode/production.js",
     "plugin.mjs",
     "setup.js",
-    "sharedPaths.cjs",
+    "sharedPaths.mjs",
     "types/index.d.ts",
     "utils.js"
   ],
@@ -46,16 +46,16 @@
   },
   "version": "7.1.0-beta.5",
   "optionalDependencies": {
+    "@fastify/htmx": "workspace:^",
     "@fastify/react": "workspace:^",
     "@fastify/vue": "workspace:^",
-    "@fastify/htmx": "workspace:^",
     "vite": "^5.4.8"
   },
   "dependencies": {
     "@fastify/middie": "^9.0.2",
     "@fastify/static": "^8.0.1",
     "fastify-plugin": "^5.0.1",
-    "find-cache-dir": "^3.3.2",
+    "find-cache-dir": "^5.0.0",
     "fs-extra": "^10.1.0",
     "html-rewriter-wasm": "^0.4.1",
     "klaw": "^4.1.0"

--- a/packages/fastify-vite/plugin.mjs
+++ b/packages/fastify-vite/plugin.mjs
@@ -1,7 +1,7 @@
 import { existsSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { ensure, write, read } from './ioutils.cjs'
-import { CACHE_DIR, CACHED_VITE_CONFIG_FILE_NAME } from './sharedPaths.cjs'
+import { CACHE_DIR, CACHED_VITE_CONFIG_FILE_NAME } from './sharedPaths.mjs'
 
 /**
  * This is the Vite plugin, not the Fastify plugin.

--- a/packages/fastify-vite/plugin.test.js
+++ b/packages/fastify-vite/plugin.test.js
@@ -4,7 +4,7 @@ import { resolve } from 'node:path'
 import { remove } from 'fs-extra'
 import { afterEach, describe, expect, test } from 'vitest'
 import { viteFastify } from './plugin.mjs'
-import { CACHED_VITE_CONFIG_FILE_NAME, CACHE_DIR } from './sharedPaths.cjs'
+import { CACHED_VITE_CONFIG_FILE_NAME, CACHE_DIR } from './sharedPaths.mjs'
 
 describe('viteFastify', () => {
   const configDistFile = resolve(CACHE_DIR, CACHED_VITE_CONFIG_FILE_NAME)

--- a/packages/fastify-vite/sharedPaths.cjs
+++ b/packages/fastify-vite/sharedPaths.cjs
@@ -1,5 +1,0 @@
-// This must stay at v3.x until the entire project moves to ESM. v4+ no longer supports CJS.
-const findCacheDir = require('find-cache-dir')
-
-module.exports.CACHE_DIR = findCacheDir({ name: '@fastify/vite' })
-module.exports.CACHED_VITE_CONFIG_FILE_NAME = 'vite.config.dist.json'

--- a/packages/fastify-vite/sharedPaths.mjs
+++ b/packages/fastify-vite/sharedPaths.mjs
@@ -1,0 +1,4 @@
+import findCacheDir from 'find-cache-dir'
+
+export const CACHE_DIR = findCacheDir({ name: '@fastify/vite' })
+export const CACHED_VITE_CONFIG_FILE_NAME = 'vite.config.dist.json'


### PR DESCRIPTION
Since `find-cache-dir` no longer supports CJS, we can simply change the one file we use it in to a `.mjs` file.