### PR TITLE
docs: Add note on CACHE_DIR for use in containers like Docker

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -99,6 +99,11 @@ export default {
   ],
 }
 ```
+
+#### CACHE_DIR
+
+Note that the location of this cached JSON file is determined by [find-cache-dir](https://www.npmjs.com/package/find-cache-dir), which requires a bit of a special consideration when working in containers like Docker or other environments in which the `node_modules` directory is not writable. If you are running in such an environment, set an environment variable named `CACHE_DIR` to any location you want. Make sure to also copy that `CACHE_DIR` directory from your build step to your final image.
+
 :::
 
 In `package.json`, take note of how the `dev`, `start` and `build` commands are defined, all just using your `server.js` file and Vite. 

--- a/packages/fastify-vite/sharedPaths.mjs
+++ b/packages/fastify-vite/sharedPaths.mjs
@@ -1,4 +1,14 @@
 import findCacheDir from 'find-cache-dir'
 
 export const CACHE_DIR = findCacheDir({ name: '@fastify/vite' })
+
+if (typeof CACHE_DIR === 'undefined') {
+	console.warn(
+		'Unable to determine CACHE_DIR.',
+		'This is likely because "node_modules/" is not writable due to running in a container.',
+		'Setting an environment variable named CACHE_DIR is recommended to get around this.',
+		'See https://fastify-vite.dev/guide/getting-started#CACHE_DIR for more details.'
+	)
+}
+
 export const CACHED_VITE_CONFIG_FILE_NAME = 'vite.config.dist.json'


### PR DESCRIPTION
Add some documentation to help developers know how to use with Docker.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
