### PR TITLE
chore: require vite plugin; remove backwards compatibility

### DIFF
--- a/packages/fastify-vite/config.js
+++ b/packages/fastify-vite/config.js
@@ -264,16 +264,9 @@ async function resolveViteConfig(root, dev, { spa } = {}) {
 
 async function resolveSSRBundle({ dev, vite }) {
   const bundle = {}
-  let clientOutDir
 
   if (!dev) {
-    if (vite.fastify) {
-      clientOutDir = resolveIfRelative(vite.fastify.clientOutDir, vite.root)
-    } else {
-      // Backwards compatibility for projects that do not use the viteFastify plugin.
-      bundle.dir = resolveIfRelative(vite.build.outDir, vite.root)
-      clientOutDir = resolve(bundle.dir, 'client')
-    }
+    const clientOutDir = resolveIfRelative(vite.fastify.clientOutDir, vite.root)
 
     const indexHtmlPath = resolve(clientOutDir, 'index.html')
     if (!exists(indexHtmlPath)) {
@@ -298,16 +291,7 @@ async function resolveSSRBundle({ dev, vite }) {
 async function resolveSPABundle({ dev, vite }) {
   const bundle = {}
   if (!dev) {
-    let clientOutDir
-
-    if (vite.fastify) {
-      clientOutDir = resolveIfRelative(vite.fastify.clientOutDir, vite.root)
-    } else {
-      // Backwards compatibility for projects that do not use the viteFastify plugin.
-      bundle.dir = resolveIfRelative(vite.build.outDir, vite.root)
-      clientOutDir = resolve(bundle.dir, 'client')
-    }
-
+    const clientOutDir = resolveIfRelative(vite.fastify.clientOutDir, vite.root)
     const indexHtmlPath = resolve(clientOutDir, 'index.html')
     if (!exists(indexHtmlPath)) {
       return

--- a/packages/fastify-vite/mode/production.js
+++ b/packages/fastify-vite/mode/production.js
@@ -19,19 +19,8 @@ function fileUrl(str) {
 
 async function setup(config) {
   const { spa, vite } = config
-  let clientOutDir
-  let serverOutDir
-
-  if (vite.fastify) {
-    clientOutDir = resolveIfRelative(vite.fastify.clientOutDir, vite.root)
-    serverOutDir = resolveIfRelative(vite.fastify.serverOutDir || '', vite.root)
-  } else {
-    // Backwards compatibility for projects that do not use the viteFastify plugin.
-    const outDir = resolveIfRelative(vite.build.outDir, vite.root)
-
-    clientOutDir = resolve(outDir, 'client')
-    serverOutDir = resolve(outDir, 'server')
-  }
+  const clientOutDir = resolveIfRelative(vite.fastify.clientOutDir, vite.root)
+  const serverOutDir = resolveIfRelative(vite.fastify.serverOutDir || '', vite.root)
 
   // For production you get the distribution version of the render function
   const { assetsDir } = vite.build


### PR DESCRIPTION
**BREAKING CHANGE:** Use of the viteFastify vite plugin is now REQUIRED

Since we are releasing 8.0.0, I figured we could fit another breaking change in here.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
