### PR TITLE
feat(fastify-htmx): allow typescript client files

### DIFF
--- a/packages/fastify-htmx/plugin.cjs
+++ b/packages/fastify-htmx/plugin.cjs
@@ -82,7 +82,7 @@ function viteFastifyHtmx(config = {}) {
         }
       },
       load(id, options) {
-        if (options?.ssr && id.endsWith('.client.js')) {
+        if (options?.ssr && (id.endsWith('.client.js') || id.endsWith('.client.ts'))) {
           return {
             code: '',
             map: null,


### PR DESCRIPTION
I noticed that client scripts could not be written in TypeScript since a check was missing in the plugin. This PR fixes that behaviour and TypeScript client scripts are now supported.

There are no tests in `fastify-htmx` yet, so I could not add any. Let me know if you have an idea how to best test this.