### PR TITLE
feat(fastify-htmx): allow for imports without file extensions

### DIFF
--- a/packages/fastify-htmx/index.js
+++ b/packages/fastify-htmx/index.js
@@ -150,6 +150,9 @@ async function findClientImports(
   const specifiers = (
     await Promise.all(
       findStaticImports(source).map(async ({ specifier }) => {
+        if (extname(specifier)) {
+          return specifier
+        }
         const resolved = resolve(dirname(path), specifier)
 
         // resolve the file extension which allows for

--- a/packages/fastify-htmx/index.js
+++ b/packages/fastify-htmx/index.js
@@ -1,5 +1,5 @@
 import { readFile } from 'node:fs/promises'
-import { dirname, join, resolve } from 'node:path'
+import { dirname, extname, join, resolve } from 'node:path'
 import { renderToStream } from '@kitajs/html/suspense.js'
 import * as devalue from 'devalue'
 import { findStaticImports, resolvePath } from 'mlly'

--- a/packages/fastify-htmx/index.js
+++ b/packages/fastify-htmx/index.js
@@ -161,7 +161,7 @@ async function findClientImports(
           const filePathWithExtension = await resolvePath(
             join(root, resolved),
             {
-              extensions: ['.mjs', '.cjs', '.js', '.ts', '.tsx'],
+              extensions: ['.mjs', '.cjs', '.js', '.jsx', '.ts', '.tsx'],
             },
           )
           const specifier = filePathWithExtension.replace(root, '')

--- a/packages/fastify-htmx/index.js
+++ b/packages/fastify-htmx/index.js
@@ -158,15 +158,7 @@ async function findClientImports(
           const filePathWithExtension = await resolvePath(
             join(root, resolved),
             {
-              extensions: [
-                '.mjs',
-                '.cjs',
-                '.js',
-                '.ts',
-                '.tsx',
-                '.css',
-                '.svg',
-              ],
+              extensions: ['.mjs', '.cjs', '.js', '.ts', '.tsx'],
             },
           )
           const specifier = filePathWithExtension.replace(root, '')


### PR DESCRIPTION
I noticed that some client imports where not properly included in vite's output. This was the setup:

`data.tsx`
```ts
import { ListItem } from "../components/ListItem"

export default async function ({ app, req, reply }) {
  return (...)
}
```

`../components/ListItem.tsx`
```ts
import type { PropsWithChildren } from "@kitajs/html";
import styles from "./ListItem.module.css";

export function ListItem({ children }: PropsWithChildren) {
  return (
    <li class={styles.ListItem} safe>
      {children}
    </li>
  );
}
```

`./ListItem.module.css`
```css
.ListItem {
  color: red;
}
```

I expected the list items to be red but they were not. Upon further investigation, I noticed that the CSS code from `ListItem.module.css` was generated but not included in the output.

The problem stemmed from this line in `data.tsx`:
```js
import { ListItem } from "../components/ListItem"
```
The import does not include the file extension but the checks in `findClientImports` rely on the file extension to be present: https://github.com/fastify/fastify-vite/blob/169b718d3f306b922c5666f659d0a201dfd8c861/packages/fastify-htmx/index.js#L152

In this PR I'm adding a step to resolve the file extension in case it's not defined. This allows for imports without file extensions to be correctly resolved and included in the bundle.