### PR TITLE
fix(fastify-htmx): add proper error handler

### DIFF
--- a/packages/fastify-htmx/index.js
+++ b/packages/fastify-htmx/index.js
@@ -8,6 +8,7 @@ export default {
   prepareClient,
   createHtmlFunction,
   createRouteHandler,
+  createErrorHandler,
 }
 
 const kPrefetch = Symbol('kPrefetch')
@@ -171,4 +172,14 @@ async function findClientImports(
     }
   }
   return { js, css, svg }
+}
+
+function createErrorHandler(_, scope, config) {
+  return (error, req, reply) => {
+    if (config.dev) {
+      scope.log.error(error)
+      scope.vite.devServer.ssrFixStacktrace(error)
+    }
+    scope.errorHandler(error, req, reply)
+  }
 }


### PR DESCRIPTION
I noticed that failing fastify schemas kept returning `500`s instead of `400`s. After some digging I understood that this default `errorHandler` (from `fastify-vite`) is attached to all routes which overwrites the default fastify error behaviour. 

https://github.com/fastify/fastify-vite/blob/e1ff9414e24051cdab06823aba4e0d256d938f81/packages/fastify-vite/config.js#L93-L101

I was not sure why all errors should be treated as `500`s, this is probably meant as a default error handler that each package should overwrite?

Imo, for `htmx` it makse sense to keep the original fastify error behaviour. This PR adds a custom `createErroHandler` to `fastify-htmx` that logs the error in `dev` mode and in all modes falls back to the default fastify behaviour.

For completeness, here's the code for the fragment that defines a custom schema:

```jsx
import { Type, } from "@fastify/type-provider-typebox";
import { ListItem } from "../components/ListItem";

export const path = "/list/add";
export const method = "POST";

const bodySchema = Type.Object({
  inputValue: Type.String(),
});
export const schema = {
  body: bodySchema,
};

export default ({ app, req }) => {
  app.db.todoList.push(req.body.inputValue);
  return <ListItem>{req.body.inputValue}</ListItem>;
};
```

