### PR TITLE
feat(fastify-htmx): Extract potential layout imports

### DIFF
--- a/packages/fastify-htmx/index.js
+++ b/packages/fastify-htmx/index.js
@@ -40,12 +40,16 @@ async function prepareClient(clientModule, scope, config) {
       }
     }
     // prefetch layout file path
-    let layout = null
+    let layoutFilePath = null
     if (route.layout) {
-      layout = await resolveLayout(config.vite.root, route.layout)
+      layoutFilePath = await resolveLayoutFilePath(
+        config.vite.root,
+        route.layout,
+      )
     } else if (defaultLayout) {
-      layout = defaultLayout
+      layoutFilePath = defaultLayout
     }
+
     // Pregenerate prefetching <head> elements
     let assets = { css: [], svg: [], js: [] }
     if (layoutFilePath) {

--- a/packages/fastify-htmx/index.js
+++ b/packages/fastify-htmx/index.js
@@ -179,7 +179,8 @@ async function findClientImports(
 ) {
   // Don't re-evaluate the file's dependencies if we've processed it before
   if (clientImportsCache.has(path)) {
-    return clientImportsCache.get(path)
+    const cached = clientImportsCache.get(path)
+    return { js: [...cached.js], css: [...cached.css], svg: [...cached.svg] }
   }
   const source = await readFile(join(root, path), 'utf8')
 

--- a/packages/fastify-htmx/index.js
+++ b/packages/fastify-htmx/index.js
@@ -177,6 +177,7 @@ async function findClientImports(
   path,
   { js = [], css = [], svg = [] } = {},
 ) {
+  // Don't re-evaluate the file's dependencies if we've processed it before
   if (clientImportsCache.has(path)) {
     return clientImportsCache.get(path)
   }
@@ -227,11 +228,16 @@ async function findClientImports(
     }
     if (specifier.match(/\.((m?js)|(tsx?)|(jsx?))$/)) {
       const submoduleImports = await findClientImports(root, resolved)
+      // always add JS submodules to the cache
       clientImportsCache.set(resolved, submoduleImports)
       js.push(...submoduleImports.js)
       css.push(...submoduleImports.css)
       svg.push(...submoduleImports.svg)
     }
+  }
+  // Always cache layouts, they're checked often
+  if (path.includes('layouts')) {
+    clientImportsCache.set(path, { js: [...js], css: [...css], svg: [...svg] })
   }
   return { js, css, svg }
 }

--- a/packages/fastify-htmx/index.js
+++ b/packages/fastify-htmx/index.js
@@ -224,14 +224,14 @@ async function findClientImports(
     if (specifier.match(/\.svg$/)) {
       svg.push(resolved.slice(1))
     }
-    if (specifier.match(/\.client\.((m?js)|(tsx?)|(jsx?))$/)) {
-      js.push(resolved.slice(1))
-    }
     if (specifier.match(/\.css$/)) {
       css.push(resolved.slice(1))
     }
     if (specifier.match(/\.((m?js)|(tsx?)|(jsx?))$/)) {
-      const submoduleImports = await findClientImports(root, resolved)
+      if (specifier.match(/\.client\.((m?js)|(tsx?)|(jsx?))$/)) {
+        js.push(resolved.slice(1))
+      }
+      const submoduleImports = await findClientImports(config, resolved)
       // always add JS submodules to the cache
       clientImportsCache.set(resolved, submoduleImports)
       js.push(...submoduleImports.js)


### PR DESCRIPTION
I noticed that CSS from layouts was not being extracted, so I added that functionality to the `prepareClient` method.

The extraction logic takes tries to resolve the specified layout or in case no layout was provided, the `layouts/default` file if one exists. No extra measures are taken when no default layout exists.

In order to speed up builds, I also added the following:
- https://github.com/fastify/fastify-vite/pull/204/commits/3385b580845eb9ae076459182e75e3c5a804a8b5 adds a cache for the layout file resolution
- https://github.com/fastify/fastify-vite/pull/204/commits/839916f94035095748190bd8ed9962fb4277edb7 adds a cache for the client imports