### PR TITLE
fix(fastify-htmx): fix compressed fragment replies

### DIFF
--- a/packages/fastify-htmx/index.js
+++ b/packages/fastify-htmx/index.js
@@ -88,7 +88,9 @@ export function createRouteHandler({ client, route }, scope, config) {
     return async (req, reply) => {
       req.route = route
       reply.type('text/html')
-      reply.send(await route.default({ app: scope, req, reply, client, route }))
+      return reply.send(
+        await route.default({ app: scope, req, reply, client, route }),
+      )
     }
   }
   return async (req, reply) => {


### PR DESCRIPTION
Fixes: https://github.com/fastify/fastify-vite/issues/205

A missing `return reply(...)` in the fragment route handler, caused `fastify-compress` to fail.
