### PR TITLE
feat(vue): wildcard route

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -2,7 +2,7 @@
 
 Currently [I'm](https://hire.jonasgalvez.com.br) the sole maintainer of this project.
 
-New contributors would be extremely wecome.
+New contributors would be extremely welcome.
 
 The project needs at least an additional releaser.
 

--- a/docs/react/router-setup.md
+++ b/docs/react/router-setup.md
@@ -35,18 +35,5 @@ export default {
 
 ## Dynamic parameters
 
-Dynamic route parameters follow the [Next.js convention](https://nextjs.org/docs/basic-features/pages#pages-with-dynamic-routes) (`[param]`), but that can be overriden by using the `paramPattern` plugin option. For example, this configuration switches the param pattern to the [Remix convention](https://remix.run/docs/en/v1/guides/routing#dynamic-segments) (`$param`).
-
-In your Vite configuration file:
-
-```js
-import viteFastifyReact from '@fastify/react/plugin'
-
-export default {
-  plugins: [
-    // ...
-    viteFastifyReact({ paramPattern: /\$(\w+)/ }),
-  ],
-}
-```
+Dynamic route parameters uses `[param]` for a singular parameter and `[param+]` for wildcard routes.
 

--- a/docs/vue/router-setup.md
+++ b/docs/vue/router-setup.md
@@ -37,24 +37,11 @@ export default {
 
 ## Dynamic parameters
 
-Dynamic route parameters follow the [Next.js convention](https://nextjs.org/docs/basic-features/pages#pages-with-dynamic-routes) (`[param]`), but that can be overriden by using the `paramPattern` plugin option. For example, this configuration switches the param pattern to the [Remix convention](https://remix.run/docs/en/v1/guides/routing#dynamic-segments) (`$param`).
-
-In your Vite configuration file:
-
-```js
-import viteFastifyVue from '@fastify/vue/plugin'
-
-export default {
-  plugins: [
-    // ...
-    viteFastifyVue({ paramPattern: /\$(\w+)/ }),
-  ],
-}
-```
+Dynamic route parameters uses `[param]` for a singular parameter and `[param+]` for wildcard routes.
 
 ## Scroll behavior
 
-Scroll behavior can be set by exporting the function `scrollBehavior` in `root.vue`. See [Scroll Bahavior](https://router.vuejs.org/guide/advanced/scroll-behavior) on how to use it.
+Scroll behavior can be set by exporting the function `scrollBehavior` in `root.vue`. See [Scroll Behavior](https://router.vuejs.org/guide/advanced/scroll-behavior) on how to use it.
 
 In your `root.vue` file:  
 

--- a/packages/fastify-react/index.js
+++ b/packages/fastify-react/index.js
@@ -168,9 +168,12 @@ export async function createRoute(
     await route.configure(scope)
   }
 
+  // Replace wildcard routes with Fastify compatible syntax
+  const routePath = route.path.replace(/:[^+]+\+/, '*')
+
   if (route.getData) {
     // If getData is provided, register JSON endpoint for it
-    scope.get(`/-/data${route.path}`, {
+    scope.get(`/-/data${routePath}`, {
       onRequest,
       async handler(req, reply) {
         reply.send(await route.getData(req.route))
@@ -184,9 +187,8 @@ export async function createRoute(
   // Extend with route context initialization module
   RouteContext.extend(client.context)
 
-  // Replace wildcard routes with Fastify compatible syntax
   scope.route({
-    url: route.path.replace(/:[^+]+\+/, "*"),
+    url: routePath,
     method: ['GET', 'POST', 'PUT', 'DELETE'],
     onRequest,
     // If either getData or onEnter are provided,

--- a/packages/fastify-react/index.js
+++ b/packages/fastify-react/index.js
@@ -184,8 +184,9 @@ export async function createRoute(
   // Extend with route context initialization module
   RouteContext.extend(client.context)
 
+  // Replace wildcard routes with Fastify compatible syntax
   scope.route({
-    url: route.path,
+    url: route.path.replace(/:[^+]+\+/, "*"),
     method: ['GET', 'POST', 'PUT', 'DELETE'],
     onRequest,
     // If either getData or onEnter are provided,

--- a/packages/fastify-react/plugin.cjs
+++ b/packages/fastify-react/plugin.cjs
@@ -38,7 +38,6 @@ function viteFastifyReact(config = {}) {
   const virtualModuleInserts = {
     'routes.js': {
       $globPattern: routing.globPattern,
-      $paramPattern: routing.paramPattern,
     },
   }
 

--- a/packages/fastify-react/virtual/routes.js
+++ b/packages/fastify-react/virtual/routes.js
@@ -1,5 +1,3 @@
-/* global $paramPattern */
-
 import { lazy } from 'react'
 
 const routeModules = import.meta.glob('$globPattern')
@@ -14,7 +12,7 @@ function getRoutes () {
   }
 }
 
-async function createRoutes(from, { param } = { param: $paramPattern }) {
+async function createRoutes(from, { param } = { param: /\[([\.\w]+\+?)\]/ }) {
   // Otherwise we get a ReferenceError, but since
   // this function is only ran once, there's no overhead
   class Routes extends Array {
@@ -60,7 +58,7 @@ async function createRoutes(from, { param } = { param: $paramPattern }) {
               path
                 // Remove /pages and .jsx extension
                 .slice(6, -4)
-                // Replace [id] with :id
+                // Replace [id] with :id and [slug+] with :slug+
                 .replace(param, (_, m) => `:${m}`)
                 // Replace '/index' with '/'
                 .replace(/\/index$/, '/')

--- a/packages/fastify-vue/plugin/virtual.js
+++ b/packages/fastify-vue/plugin/virtual.js
@@ -25,7 +25,7 @@ const virtualModules = [
   'hooks'
 ]
 
-export const prefix = /^\$app\//
+export const prefix = /^\/?\$app\//
 
 export async function resolveId (id) {
   if (prefix.test(id)) {

--- a/packages/fastify-vue/routing.js
+++ b/packages/fastify-vue/routing.js
@@ -120,8 +120,10 @@ export async function createRoute ({ client, errorHandler, route }, scope, confi
   }
 
   // Replace wildcard routes with Fastify compatible syntax
+  const routePath = route.path.replace(/:[^+]+\+/, '*')
+
   scope.route({
-    url: route.path.replace(/:[^+]+\+/, "*"),
+    url: routePath,
     method: route.method ?? ['GET', 'POST', 'PUT', 'DELETE'],
     errorHandler,
     onRequest,
@@ -132,7 +134,7 @@ export async function createRoute ({ client, errorHandler, route }, scope, confi
 
   if (route.getData) {
     // If getData is provided, register JSON endpoint for it
-    scope.get(`/-/data${route.path}`, {
+    scope.get(`/-/data${routePath}`, {
       onRequest,
       async handler (req, reply) {
         reply.send(await route.getData(req.route))

--- a/packages/fastify-vue/routing.js
+++ b/packages/fastify-vue/routing.js
@@ -119,8 +119,9 @@ export async function createRoute ({ client, errorHandler, route }, scope, confi
     handler = (_, reply) => htmlFunction.call(reply)
   }
 
+  // Replace wildcard routes with Fastify compatible syntax
   scope.route({
-    url: route.path,
+    url: route.path.replace(/:[^+]+\+/, "*"),
     method: route.method ?? ['GET', 'POST', 'PUT', 'DELETE'],
     errorHandler,
     onRequest,

--- a/starters/react-kitchensink/client/pages/index.jsx
+++ b/starters/react-kitchensink/client/pages/index.jsx
@@ -28,6 +28,7 @@ export default function Index () {
         <li><Link to="/client-only">/client-only</Link> — <b>disabling</b> SSR.</li>
         <li><Link to="/server-only">/server-only</Link> — <code>0kb</code> JavaScript.</li>
         <li><Link to="/streaming">/streaming</Link> — <b>streaming</b> SSR.</li>
+        <li><Link to="/wildcard/another/one">/wildcard/another/one</Link> — <b>wildcard route matching</b> <code>/wildcard/*</code></li>
       </ul>
     </>
   )

--- a/starters/react-kitchensink/client/pages/wildcard/[slug+].jsx
+++ b/starters/react-kitchensink/client/pages/wildcard/[slug+].jsx
@@ -1,0 +1,22 @@
+import { useRouteContext } from '/:core.jsx'
+
+export function getData ({ req }) {
+  let pathMatch = req.params['*'];
+  if (pathMatch.charAt(pathMatch.length - 1) == '/') {
+    pathMatch = pathMatch.substr(0, pathMatch.length - 1);
+  }
+
+  return {
+    pathMatch: pathMatch.split('/'),
+  }
+}
+
+export default function Wildcard () {
+  const { data } = useRouteContext()
+  return (
+    <>
+      <h1>Wildcard example that matches /wildcard/*</h1>
+      <p>Path match: { data.pathMatch }</p>
+    </>
+  )
+}

--- a/starters/react-kitchensink/package.json
+++ b/starters/react-kitchensink/package.json
@@ -14,7 +14,7 @@
     "@fastify/one-line-logger": "^1.4.0",
     "@fastify/react": "workspace:^",
     "@fastify/vite": "workspace:^",
-    "fastify": "^5.0.0",
+    "fastify": "^5.2.2",
     "history": "^5.3.0",
     "minipass": "^7.1.2",
     "react": "^18.3.1",

--- a/starters/vue-base/client/index.html
+++ b/starters/vue-base/client/index.html
@@ -10,5 +10,5 @@
 <div id="root"><!-- element --></div>
 </body>
 <!-- hydration -->
-<script type="module" src="$app/mount.js"></script>
+<script type="module" src="/$app/mount.js"></script>
 </html>

--- a/starters/vue-kitchensink/client/index.html
+++ b/starters/vue-kitchensink/client/index.html
@@ -10,5 +10,5 @@
     <div id="root"><!-- element --></div>
   </body>
   <!-- hydration -->
-  <script type="module" src="/:mount.js"></script>
+  <script type="module" src="/$app/mount.js"></script>
 </html>

--- a/starters/vue-kitchensink/client/pages/index.vue
+++ b/starters/vue-kitchensink/client/pages/index.vue
@@ -9,6 +9,7 @@
     <li><router-link to="/client-only">/client-only</router-link> — <b>disabling</b> SSR.</li>
     <li><router-link to="/server-only">/server-only</router-link> — <code>0kb</code> JavaScript.</li>
     <li><router-link to="/streaming">/streaming</router-link> — <b>streaming</b> SSR.</li>
+    <li><router-link to="/wildcard/another/one">/wildcard/another/one</router-link> — <b>wildcard route matching</b> <code>/wildcard/*</code></li>
   </ul>
 </template>
 

--- a/starters/vue-kitchensink/client/pages/wildcard/[slug+].vue
+++ b/starters/vue-kitchensink/client/pages/wildcard/[slug+].vue
@@ -1,0 +1,24 @@
+<script>
+export const layout = 'default'
+
+export function getData ({ req }) {
+  let pathMatch = req.params['*'];
+  if (pathMatch.charAt(pathMatch.length - 1) == '/') {
+    pathMatch = pathMatch.substr(0, pathMatch.length - 1);
+  }
+
+  return {
+    pathMatch: pathMatch.split('/'),
+  }
+}
+</script>
+
+<script setup>
+import { useData } from '$app/hooks'
+const data = useData()
+</script>
+
+<template>
+  <h1>Wildcard example that matches /wildcard/*</h1>
+  <p>Path match: {{ data.pathMatch }}</p>
+</template>

--- a/starters/vue-kitchensink/client/root.vue
+++ b/starters/vue-kitchensink/client/root.vue
@@ -1,5 +1,5 @@
 <script>
-export { default } from '/:router.vue'
+export { default } from '$app/router.vue'
 
 export const mount = '#root'
 

--- a/starters/vue-kitchensink/package.json
+++ b/starters/vue-kitchensink/package.json
@@ -10,8 +10,8 @@
   "dependencies": {
     "@fastify/formbody": "^8.0.2",
     "@fastify/one-line-logger": "^2.0.2",
-    "@fastify/vite": "8.0.0-beta.1",
-    "@fastify/vue": "1.0.0-beta.1",
+    "@fastify/vite": "workspace:^",
+    "@fastify/vue": "workspace:^",
     "fastify": "^5.2.2",
     "html-rewriter-wasm": "^0.4.1",
     "unihead": "^0.8.0",


### PR DESCRIPTION
This removes the configurable route parameter regex and sets it to use `[slug]` for singular parameters and `[slug+]` for wildcard routes. This enables routes like `/product-category/[first-slug]/[second-slug]` (and so on) to be matched by a `[slug+].vue` file.
This also enables `catch-all` functionality by placing a `[slug+].vue` file in the client root if you want to dynamically render routes. This also adds a name to the vue routes for `{ name: ... }` routing.

Also fixes the `vue-kitchensink` starter.

**NOTE:** I couldn't get the react-kitchensink starter to work

#### Checklist

- [*] run `npm run test` and `npm run benchmark`
- [*] tests and/or benchmarks are included (kitchensink starter)
- [*] documentation is changed or added
- [*] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
