### PR TITLE
fix: avoid a wildcard route for serving public files

### DIFF
--- a/packages/fastify-vite/mode/production.js
+++ b/packages/fastify-vite/mode/production.js
@@ -66,6 +66,7 @@ async function setup(config) {
   await this.scope.register(async function publicFiles(scope) {
     await scope.register(FastifyStatic, {
       root: clientOutDir,
+      wildcard: false,
       allowedPath(path) {
         return path !== '/index.html'
       },


### PR DESCRIPTION
Fixes #184 by using `wildcard: false` of `fastify-static` in production, which creates separate routes for each file instead of adding a route for `/*`.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
