### PR TITLE
fix(vue): preload links

### DIFF
--- a/packages/fastify-vue/plugin/preload.js
+++ b/packages/fastify-vue/plugin/preload.js
@@ -23,15 +23,15 @@ export async function closeBundle() {
       let imagePreloads = '\n'
       for (let image of images) {
         image = image.slice(this.root.length + 1)
-        imagePreloads += `  <link rel="preload" as="image" href="${this.resolvedConfig.base}${image}">\n`
+        imagePreloads += `  <link rel="preload" as="image" crossorigin href="${this.resolvedConfig.base}${image}">\n`
       }
       let cssPreloads = ''
       for (const css of cssImports) {
-        cssPreloads += `  <link rel="preload" as="style" href="${this.resolvedConfig.base}${css}">\n`
+        cssPreloads += `  <link rel="preload" as="style" crossorigin href="${this.resolvedConfig.base}${css}">\n`
       }
       let jsPreloads = ''
       for (const js of jsImports) {
-        jsPreloads += `  <link rel="modulepreload" href="${this.resolvedConfig.base}${js}">\n`
+        jsPreloads += `  <link rel="modulepreload" crossorigin href="${this.resolvedConfig.base}${js}">\n`
       }
       const pageHtml = await appendHead(
         this.indexHtml,


### PR DESCRIPTION
Links are generated with `crossorigin` while the preloads aren't, giving a warning (see below). This adds the `crossorigin` attribute to the preloads as well.

> A preload for 'http://localhost/assets/edit-CXVK0aaf.css' is found, but is not used because the request credentials mode does not match. Consider taking a look at crossorigin attribute.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
