### PR TITLE
fix(vue): glob paths prefix on win32

### DIFF
--- a/packages/fastify-vue/plugin/virtual.js
+++ b/packages/fastify-vue/plugin/virtual.js
@@ -28,6 +28,11 @@ const virtualModules = [
 export const prefix = /^\/?\$app\//
 
 export async function resolveId (id) {
+  // Paths are prefixed with .. on Windows by the glob import
+  if (process.platform === 'win32' && /^\.\.\/[C-Z]:/.test(id)) {
+    return id.substring(3)
+  }
+
   if (prefix.test(id)) {
     const [, virtual] = id.split(prefix)
     if (virtual) {


### PR DESCRIPTION
This fixes the glob (`/pages/**/*.vue`) import paths being prefixed with `../`, e.g. `../C:/Users/Dev/Documents/vue-base/client/pages/index.vue`.
Fixes: #229 

Possibly a rollup/tinyglob bug when using glob inside of a virtual path ($app/routes.js) on Windows. Quite a "hacky fix" (as usual with windows) but I wasn't able to figure out where the actual issue lies.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
