### PR TITLE
Support having an "src" directory and a custom server build process

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,8 @@
 	"javascript.format.semicolons": "remove",
 	"typescript.format.semicolons": "remove",
 	"javascript.preferences.quoteStyle": "auto",
-	"typescript.preferences.quoteStyle": "auto"
+	"typescript.preferences.quoteStyle": "auto",
+	"[markdown]": {
+		"editor.formatOnSave": false,
+	}
 }

--- a/docs/guide/build-and-deploy.md
+++ b/docs/guide/build-and-deploy.md
@@ -3,7 +3,7 @@
 
 # Build and Deploy
 
-You'll quickly notice running your Fastify server without the `--dev` flag can get you the following error message:
+Without building, you will quickly notice running your Fastify server without the `--dev` flag can get you the following error message:
 
 ```
 % node server.js
@@ -14,46 +14,129 @@ You'll quickly notice running your Fastify server without the `--dev` flag can g
 Error: No distribution bundle found.
 ```
 
-This means you're trying to run **`@fastify/vite`** in production mode, in which case a **distribution bundle** is assumed to exist. To build your client application code in preparation for **`@fastify/vite`**, you must run two `vite build` commands, one for the actual client bundle, that gets delivered to the browser, and another for the server-side version of it (what **`@fastify/vite`** sees as the *_client module_*, or *_server entry point_*).
+This means you're trying to run **`@fastify/vite`** in production mode, in which case a **distribution bundle** is assumed to exist. You need to first build your application code in preparation for **`@fastify/vite`**.
 
-Assuming you're using the default `clientModule` resolution (`/index.js`), these are the `scripts` needed in `package.json`:
+## Building multiple bundles
 
-```json
+Depending on your application, there can be up to _three_ distribution bundles:
+
+1. The bundle that gets delivered to the **browser**. Required no matter what.
+2. The bundle used for **server side rendering** (SSR). Only required if you intend to use server side rendering.
+3. The "bundle" that contains the code that instantiates the **Fastify server itself**. Some servers need this, such as ones that are written in TypeScript and do not want to use type-stripping. This build process is entirely up to you.
+
+Building the **browser bundle** and the **ssr bundle** can be accomplished by running a single `vite build` command. Their entry points are as follows:
+
+```text{2,3}
+├── client/
+│    ├── index.js <-- ssr entry point (default)
+│    ├── mount.js <-- browser entry point
+│    └── index.html
+```
+
+You can use the included Vite plugin to customize the SSR build:
+
+```js{7}
+import { resolve } from 'node:path'
+import viteFastify from '@fastify/vite/plugin'
+
+export default {
+  root: resolve(import.meta.dirname, 'client'),
+  plugins: [
+    viteFastify({/* see below for available options */})
+  ],
+}
+```
+
+The `viteFastify` plugin can be given the following options:
+
+* `spa` - Set this to `true` to disable the SSR build entirely. Default: `false`.
+* `clientModule` - The location of the SSR entry point, relative to the index.html file. Defaults to `index.js`. You can also use an absolute path to be extra safe.
+* `outDir` - The location to output built files. Defaults to `${root}/dist`.
+
+Assuming you do not need to build your Fastify server itself, the only build script you need in your `package.json` file is below:
+
+```json{3}
 {
   "scripts": {
-    "build": "npm run build:client && npm run build:server",
-    "build:client": "vite build --outDir dist/client --ssrManifest",
-    "build:server": "vite build --outDir dist/server --ssr /index.js",
+    "build": "vite build"
   }
 }
 ```
 
-If you're using a **different** [`clientModule`](/config/#clientmodule) settings, you *will* need to change the `build:server` command accordingly, i.e., that's not taken care of by `**@fastify/vite**`. After running `npm run build` on [`react-vanilla`](https://github.com/fastify/fastify-vite/tree/dev/examples/react-vanilla), for example, you should see a new `client/dist` folder.
+If you **do** need to run a custom build process on the code that instantiates the Fastify server itself, your `package.json` file likely contains the scripts below:
 
-```diff
-  ├── client
-+ │    ├── dist
-  │    ├── base.jsx
-  │    ├── index.html
-  │    ├── index.js
-  │    └── mount.js
-  ├── package.json
-  ├── server.js
-  └── vite.config.js
+```json{5}
+{
+  "scripts": {
+    "build": "npm run build:client && npm run build:server",
+    "build:client": "vite build",
+    "build:server": "tsc",
+  }
+}
 ```
 
-That's where the production bundle of your Vite application is located, so this folder needs to exist before you can run a Fastify server with **`@fastify/vite`** in production mode. Once you have `client/dist` available, `node server.js` without the `--dev` flag should be able to run.
+In the example above, `tsc` is used as the custom build process for the server code, but this can be replaced with whatever you need to use. If you do this, you probably want to customize the location of your dist directory (see below).
+
+### The dist directory
+
+The `vite build` script above creates a `dist` directory with the following contents:
+
+```text
+├── dist/
+│    ├── client/  (contains client bundle)
+│    └── ssr/     (contains ssr bundle, if enabled)
+```
+
+Depending on whether you have decided to use a `src` directory, you may also want to customize where your `dist` directory is located. This especially true if you have a custom build process for your server code. Common locations for the `dist` directory can be:
+
+1. Within the client folder, aka the location specified as the `root` of your `vite.config.js` file. This is the default and is recommended if you do not run a custom build for your server code.
+2. At the root of the application. If you run a custom build for your server code, it generally builds into a dist folder that is a sibling to the your application's `package.json` file. In this case, you likely want to put your client and SSR bundles into this folder as well.
+
+If you choose to go with (2), your `dist` folder should also contain the built server files at its root level:
+
+```diff
+  ├── dist/
+  │    ├── client/    (contains client bundle)
+  │    ├── ssr/       (contains ssr bundle, if enabled)
++ |    └── server.js  (the built server files)
+```
+
+To achieve this, you need to do two things:
+
+1. Instruct the included `viteFastify` plugin to output its files into your custom `dist` directory location using the `outDir` option.
+2. Instruct your custom build process to output the built server files into the same `dist` directory.
+
+If you do not do the above two steps, you could end up with two separate `dist` folders that you will need to handle on your own. Below is an example of this setup using `tsc` as the custom server build process:
+
+::: code-group
+```js{7} [vite.config.js]
+import { resolve } from 'node:path'
+import viteFastify from '@fastify/vite/plugin'
+
+export default {
+  root: resolve(import.meta.dirname, 'client'),
+  plugins: [
+    viteFastify({ outDir: resolve(import.meta.dirname, 'dist') })
+  ],
+}
+```
+```json{3} [tsconfig.json]
+{
+  "compilerOptions": {
+    "outDir": "dist"
+  }
+}
+```
+:::
+
+> Note that `vite` itself also has a [build.outDir](https://vite.dev/config/build-options.html#build-outdir) configuration. Do **not** use this configuration as it is unclear whether it is intended for the client bundle or the SSR bundle. Use the `outDir` option of the included `viteFastify` plugin instead.
+
+## Running in production mode
+
+Once your build processes are complete and your `dist` directory is populated, you should be able to run a Fastify server with **`@fastify/vite`** in production mode. Run `node server.js` without the `--dev` flag to see. Don't forget to include your `dist` directory as part of your deployment.
 
 > Make sure to have `NODE_ENV` set to `production` as well in case your framework requires it (like React) for SSR in production as well. Accidentally running React SSR in development mode is quite common and can lead to serious performance degradation.
 
-Also note that in **production mode**, **`@fastify/vite`** will serve static assets from your Vite application via [`@fastify/static`](https://github.com/fastify/fastify-static) automatically, but you should consider using a CDN for those files if you can, or just serve through Nginx  instead of directly through Node.js.
+Also note that in **production mode**, **`@fastify/vite`** will serve static assets from your Vite application via [`@fastify/static`](https://github.com/fastify/fastify-static) automatically, but you should consider using a CDN for those files if you can, or just serve through Nginx instead of directly through Node.js.
 
 If you don't need SSR, it can also just serve as a convenience to serve your static Vite bundle through Fastify via [@fastify/static][fastify-static], automatically inferring your bundle's output directory from your Vite configuration file, and still allowing you to leverage Vite's development server for hot reload.
-
-## Steps
-
-To recap, the steps to build and deploy are:
-
-- Running vite build with client configuration.
-- Running vite build with server configuration.
-- Including `client/dist` as part of your deployment.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -152,25 +152,39 @@ export function createApp () {
 
 ## Directory structure
 
-This is what the directory structure for the example above looks like:
+**`@fastify/vite`** recommends one of the following directory structures for your application:
 
-```text{1,5,6}
+::: code-group
+```text{2,5,6} [without src directory]
+// For very simple servers
 ├── server.js
 ├── client/
-│    ├── base.jsx
 │    ├── mount.js
 │    └── index.html
 ├── vite.config.js
 └── package.json
 ```
+```text{3,6,7} [with src directory]
+// For servers that have many files or require a build step
+├── src/
+|    ├── server.js
+|    └── client/
+│        ├── mount.js
+│        └── index.html
+├── vite.config.js
+└── package.json
+```
+:::
+
+The choice to use a `src` directory or not is up to you. The primary benefit of using a `src` directory is if your server code requires any kind of build step where you want to separate your `src` files from `dist` files. For example, if your server is written in TypeScript you most likely want your `src` and `dist` files to be separate. It is also not uncommon for server code to be built using Webpack or Rollup. Even if your server does not require a build step, you may want to use a `src` directory anyway for better organization if your server code is divided into many files.
 
 In all examples in this documentation, the client application code is kept in a `client/` directory, to be explicitly separated from the server code and configuration files. In the `vite.config.js` previously shown, the project **root** is set as `client`.  This is the recommended approach.
 
 ::: warning
-It's important to realize that in `server.js`, the `root` configuration option determines where your `vite.config.js` is located. But in `vite.config.js` itself, the `root` configuration option determines your **project root** in Vite's context.
+It's important to realize that in `server.js`, the `root` configuration option determines where your `vite.config.js` is located. But in `vite.config.js` itself, the `root` configuration option determines where your `index.html` is located. This is your **project root** in Vite's context.
 :::
 
-Regardless of whether you want to simply deliver a SPA bundle to the browser or perform SSR, projects using `@fastify/vite` will always need a minimum of **three files**: the Fastify **server**, an [index.html file](https://vitejs.dev/guide/#index-html-and-project-root) and a [Vite configuration file](https://vitejs.dev/config/).
+Regardless of whether you want to simply deliver a SPA bundle to the browser or perform SSR, projects using **`@fastify/vite`** will always need a minimum of **three files**: the Fastify **server**, an [index.html file](https://vitejs.dev/guide/#index-html-and-project-root) and a [Vite configuration file](https://vitejs.dev/config/).
 
 ## Architectural primitives
 


### PR DESCRIPTION
This PR is a Work in Progress. My thinking is to write the docs first so we can align on the approach, and then write the code.

The official release of 8.0.0 kind of threw away support for also running a build step on the server code that instantiates the Fastify server itself. Many real world applications _need_ this build step, such as those written in TypeScript. These docs are how I envision we can go about supporting them. Once we have alignment I will make the code changes.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
