### PR TITLE
fix: add typing for decorators and routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   "private": "true",
   "devDependencies": {
     "execa": "^9.5.2",
-    "fastify": "^5.2.2",
     "oxlint": "^0.9.10",
     "vite": "^6.2.5",
     "vitest": "^1.3.0",

--- a/packages/fastify-vite/package.json
+++ b/packages/fastify-vite/package.json
@@ -45,10 +45,10 @@
   },
   "version": "8.0.5",
   "optionalDependencies": {
-    "vite": "^6.2.4",
-    "@fastify/vue": "workspace:^",
+    "@fastify/htmx": "workspace:^",
     "@fastify/react": "workspace:^",
-    "@fastify/htmx": "workspace:^"
+    "@fastify/vue": "workspace:^",
+    "vite": "^6.2.4"
   },
   "dependencies": {
     "@fastify/deepmerge": "^3.0.0",
@@ -64,7 +64,7 @@
     "@biomejs/biome": "^1.9.4",
     "@types/node": "^22.13.17",
     "@vitest/ui": "^3.1.1",
-    "fastify": "^5.2.2",
+    "fastify": "^5.3.2",
     "typescript": "~5.8.2",
     "vitest": "^3.1.1"
   },
@@ -72,5 +72,8 @@
     "fastify": ">=5",
     "vite": ">=5"
   },
-  "keywords": ["fastify", "vite"]
+  "keywords": [
+    "fastify",
+    "vite"
+  ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ catalogs:
       specifier: ^5.1.1
       version: 5.1.1
     fastify:
-      specifier: ^5.2.2
+      specifier: ^5.3.2
       version: 5.2.2
     oxlint:
       specifier: ^0.16.6
@@ -59,9 +59,6 @@ importers:
       execa:
         specifier: ^9.5.2
         version: 9.5.2
-      fastify:
-        specifier: ^5.2.2
-        version: 5.2.2
       oxlint:
         specifier: ^0.9.10
         version: 0.9.10
@@ -952,8 +949,8 @@ importers:
         specifier: ^3.1.1
         version: 3.1.1(vitest@3.1.1)
       fastify:
-        specifier: ^5.2.2
-        version: 5.2.2
+        specifier: ^5.3.2
+        version: 5.3.2
       typescript:
         specifier: ~5.8.2
         version: 5.8.2
@@ -1153,13 +1150,13 @@ importers:
         version: 2.0.2
       '@fastify/react':
         specifier: latest
-        version: 1.0.2(@kitajs/ts-html-plugin@4.1.1(@kitajs/html@4.2.7)(typescript@5.8.3))(@types/node@22.14.0)(@types/react@19.1.2)(fastify@5.2.2)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.39.0)(tsx@4.19.3)(typescript@5.8.3)(yaml@2.7.1)
+        version: 1.0.2(@kitajs/ts-html-plugin@4.1.1(@kitajs/html@4.2.7)(typescript@5.8.3))(@types/node@22.14.0)(@types/react@19.1.2)(fastify@5.3.2)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.39.0)(tsx@4.19.3)(typescript@5.8.3)(yaml@2.7.1)
       '@fastify/vite':
         specifier: latest
-        version: 8.0.5(@kitajs/ts-html-plugin@4.1.1(@kitajs/html@4.2.7)(typescript@5.8.3))(@types/node@22.14.0)(@types/react@19.1.2)(fastify@5.2.2)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.39.0)(tsx@4.19.3)(typescript@5.8.3)(yaml@2.7.1)
+        version: 8.0.5(@kitajs/ts-html-plugin@4.1.1(@kitajs/html@4.2.7)(typescript@5.8.3))(@types/node@22.14.0)(@types/react@19.1.2)(fastify@5.3.2)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.39.0)(tsx@4.19.3)(typescript@5.8.3)(yaml@2.7.1)
       fastify:
-        specifier: ^5.2.2
-        version: 5.2.2
+        specifier: ^5.3.2
+        version: 5.3.2
       history:
         specifier: ^5.3.0
         version: 5.3.0
@@ -1219,8 +1216,8 @@ importers:
         specifier: workspace:^
         version: link:../../packages/fastify-vite
       fastify:
-        specifier: ^5.2.2
-        version: 5.2.2
+        specifier: ^5.3.2
+        version: 5.3.2
       history:
         specifier: ^5.3.0
         version: 5.3.0
@@ -1280,7 +1277,7 @@ importers:
         specifier: workspace:^
         version: link:../../packages/fastify-vite
       fastify:
-        specifier: ^5.2.2
+        specifier: ^5.3.2
         version: 5.3.2
       history:
         specifier: ^5.3.0
@@ -1348,13 +1345,13 @@ importers:
         version: 2.0.2
       '@fastify/vite':
         specifier: 8.0.0
-        version: 8.0.0(@kitajs/ts-html-plugin@4.1.1(@kitajs/html@4.2.7)(typescript@5.8.3))(@types/node@22.14.0)(@types/react@19.1.2)(fastify@5.2.2)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.39.0)(tsx@4.19.3)(typescript@5.8.3)(yaml@2.7.1)
+        version: 8.0.0(@kitajs/ts-html-plugin@4.1.1(@kitajs/html@4.2.7)(typescript@5.8.3))(@types/node@22.14.0)(@types/react@19.1.2)(fastify@5.3.2)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.39.0)(tsx@4.19.3)(typescript@5.8.3)(yaml@2.7.1)
       '@fastify/vue':
         specifier: 1.0.0
-        version: 1.0.0(@kitajs/ts-html-plugin@4.1.1(@kitajs/html@4.2.7)(typescript@5.8.3))(@types/node@22.14.0)(@types/react@19.1.2)(fastify@5.2.2)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.39.0)(tsx@4.19.3)(typescript@5.8.3)(yaml@2.7.1)
+        version: 1.0.0(@kitajs/ts-html-plugin@4.1.1(@kitajs/html@4.2.7)(typescript@5.8.3))(@types/node@22.14.0)(@types/react@19.1.2)(fastify@5.3.2)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.39.0)(tsx@4.19.3)(typescript@5.8.3)(yaml@2.7.1)
       fastify:
-        specifier: ^5.2.2
-        version: 5.2.2
+        specifier: ^5.3.2
+        version: 5.3.2
       unihead:
         specifier: ^0.8.0
         version: 0.8.0
@@ -1397,13 +1394,13 @@ importers:
         version: 2.0.2
       '@fastify/vite':
         specifier: 8.0.0
-        version: 8.0.0(@kitajs/ts-html-plugin@4.1.1(@kitajs/html@4.2.7)(typescript@5.8.3))(@types/node@22.14.0)(@types/react@19.1.2)(fastify@5.2.2)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.39.0)(tsx@4.19.3)(typescript@5.8.3)(yaml@2.7.1)
+        version: 8.0.0(@kitajs/ts-html-plugin@4.1.1(@kitajs/html@4.2.7)(typescript@5.8.3))(@types/node@22.14.0)(@types/react@19.1.2)(fastify@5.3.2)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.39.0)(tsx@4.19.3)(typescript@5.8.3)(yaml@2.7.1)
       '@fastify/vue':
         specifier: 1.0.0
-        version: 1.0.0(@kitajs/ts-html-plugin@4.1.1(@kitajs/html@4.2.7)(typescript@5.8.3))(@types/node@22.14.0)(@types/react@19.1.2)(fastify@5.2.2)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.39.0)(tsx@4.19.3)(typescript@5.8.3)(yaml@2.7.1)
+        version: 1.0.0(@kitajs/ts-html-plugin@4.1.1(@kitajs/html@4.2.7)(typescript@5.8.3))(@types/node@22.14.0)(@types/react@19.1.2)(fastify@5.3.2)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.39.0)(tsx@4.19.3)(typescript@5.8.3)(yaml@2.7.1)
       fastify:
-        specifier: ^5.2.2
-        version: 5.2.2
+        specifier: ^5.3.2
+        version: 5.3.2
       html-rewriter-wasm:
         specifier: ^0.4.1
         version: 0.4.1
@@ -1451,7 +1448,7 @@ importers:
         specifier: workspace:^
         version: link:../../packages/fastify-vue
       fastify:
-        specifier: ^5.2.2
+        specifier: ^5.3.2
         version: 5.3.2
       html-rewriter-wasm:
         specifier: ^0.4.1
@@ -8792,9 +8789,9 @@ snapshots:
       - terser
     optional: true
 
-  '@fastify/react@1.0.2(@kitajs/ts-html-plugin@4.1.1(@kitajs/html@4.2.7)(typescript@5.8.3))(@types/node@22.14.0)(@types/react@19.1.2)(fastify@5.2.2)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.39.0)(tsx@4.19.3)(typescript@5.8.3)(yaml@2.7.1)':
+  '@fastify/react@1.0.2(@kitajs/ts-html-plugin@4.1.1(@kitajs/html@4.2.7)(typescript@5.8.3))(@types/node@22.14.0)(@types/react@19.1.2)(fastify@5.3.2)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.39.0)(tsx@4.19.3)(typescript@5.8.3)(yaml@2.7.1)':
     dependencies:
-      '@fastify/vite': 8.0.5(@kitajs/ts-html-plugin@4.1.1(@kitajs/html@4.2.7)(typescript@5.8.3))(@types/node@22.14.0)(@types/react@19.1.2)(fastify@5.2.2)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.39.0)(tsx@4.19.3)(typescript@5.8.3)(yaml@2.7.1)
+      '@fastify/vite': 8.0.5(@kitajs/ts-html-plugin@4.1.1(@kitajs/html@4.2.7)(typescript@5.8.3))(@types/node@22.14.0)(@types/react@19.1.2)(fastify@5.3.2)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.39.0)(tsx@4.19.3)(typescript@5.8.3)(yaml@2.7.1)
       acorn: 8.14.1
       acorn-strip-function: 1.2.0
       acorn-walk: 8.3.4
@@ -8879,12 +8876,12 @@ snapshots:
       - sugarss
       - terser
 
-  '@fastify/vite@8.0.0(@kitajs/ts-html-plugin@4.1.1(@kitajs/html@4.2.7)(typescript@5.8.3))(@types/node@22.14.0)(@types/react@19.1.2)(fastify@5.2.2)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.39.0)(tsx@4.19.3)(typescript@5.8.3)(yaml@2.7.1)':
+  '@fastify/vite@8.0.0(@kitajs/ts-html-plugin@4.1.1(@kitajs/html@4.2.7)(typescript@5.8.3))(@types/node@22.14.0)(@types/react@19.1.2)(fastify@5.3.2)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.39.0)(tsx@4.19.3)(typescript@5.8.3)(yaml@2.7.1)':
     dependencies:
       '@fastify/deepmerge': 3.1.0
       '@fastify/middie': 9.0.3
       '@fastify/static': 8.1.1
-      fastify: 5.2.2
+      fastify: 5.3.2
       fastify-plugin: 5.0.1
       find-cache-dir: 5.0.0
       fs-extra: 11.3.0
@@ -8893,7 +8890,7 @@ snapshots:
     optionalDependencies:
       '@fastify/htmx': 0.4.0(@kitajs/ts-html-plugin@4.1.1(@kitajs/html@4.2.7)(typescript@5.8.3))(rollup@4.39.0)
       '@fastify/react': 0.6.0(@types/node@22.14.0)(@types/react@19.1.2)(lightningcss@1.29.2)
-      '@fastify/vue': 1.0.0(@kitajs/ts-html-plugin@4.1.1(@kitajs/html@4.2.7)(typescript@5.8.3))(@types/node@22.14.0)(@types/react@19.1.2)(fastify@5.2.2)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.39.0)(tsx@4.19.3)(typescript@5.8.3)(yaml@2.7.1)
+      '@fastify/vue': 1.0.0(@kitajs/ts-html-plugin@4.1.1(@kitajs/html@4.2.7)(typescript@5.8.3))(@types/node@22.14.0)(@types/react@19.1.2)(fastify@5.3.2)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.39.0)(tsx@4.19.3)(typescript@5.8.3)(yaml@2.7.1)
       vite: 6.3.2(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(yaml@2.7.1)
     transitivePeerDependencies:
       - '@kitajs/ts-html-plugin'
@@ -8912,12 +8909,12 @@ snapshots:
       - typescript
       - yaml
 
-  '@fastify/vite@8.0.5(@kitajs/ts-html-plugin@4.1.1(@kitajs/html@4.2.7)(typescript@5.8.3))(@types/node@22.14.0)(@types/react@19.1.2)(fastify@5.2.2)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.39.0)(tsx@4.19.3)(typescript@5.8.3)(yaml@2.7.1)':
+  '@fastify/vite@8.0.5(@kitajs/ts-html-plugin@4.1.1(@kitajs/html@4.2.7)(typescript@5.8.3))(@types/node@22.14.0)(@types/react@19.1.2)(fastify@5.3.2)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.39.0)(tsx@4.19.3)(typescript@5.8.3)(yaml@2.7.1)':
     dependencies:
       '@fastify/deepmerge': 3.1.0
       '@fastify/middie': 9.0.3
       '@fastify/static': 8.1.1
-      fastify: 5.2.2
+      fastify: 5.3.2
       fastify-plugin: 5.0.1
       find-cache-dir: 5.0.0
       fs-extra: 11.3.0
@@ -8925,8 +8922,8 @@ snapshots:
       klaw: 4.1.0
     optionalDependencies:
       '@fastify/htmx': 0.4.0(@kitajs/ts-html-plugin@4.1.1(@kitajs/html@4.2.7)(typescript@5.8.3))(rollup@4.39.0)
-      '@fastify/react': 1.0.2(@kitajs/ts-html-plugin@4.1.1(@kitajs/html@4.2.7)(typescript@5.8.3))(@types/node@22.14.0)(@types/react@19.1.2)(fastify@5.2.2)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.39.0)(tsx@4.19.3)(typescript@5.8.3)(yaml@2.7.1)
-      '@fastify/vue': 1.0.6(@kitajs/ts-html-plugin@4.1.1(@kitajs/html@4.2.7)(typescript@5.8.3))(@types/node@22.14.0)(@types/react@19.1.2)(fastify@5.2.2)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.39.0)(tsx@4.19.3)(typescript@5.8.3)(yaml@2.7.1)
+      '@fastify/react': 1.0.2(@kitajs/ts-html-plugin@4.1.1(@kitajs/html@4.2.7)(typescript@5.8.3))(@types/node@22.14.0)(@types/react@19.1.2)(fastify@5.3.2)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.39.0)(tsx@4.19.3)(typescript@5.8.3)(yaml@2.7.1)
+      '@fastify/vue': 1.0.6(@kitajs/ts-html-plugin@4.1.1(@kitajs/html@4.2.7)(typescript@5.8.3))(@types/node@22.14.0)(@types/react@19.1.2)(fastify@5.3.2)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.39.0)(tsx@4.19.3)(typescript@5.8.3)(yaml@2.7.1)
       vite: 6.3.2(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.3)(yaml@2.7.1)
     transitivePeerDependencies:
       - '@kitajs/ts-html-plugin'
@@ -8945,9 +8942,9 @@ snapshots:
       - typescript
       - yaml
 
-  '@fastify/vue@1.0.0(@kitajs/ts-html-plugin@4.1.1(@kitajs/html@4.2.7)(typescript@5.8.3))(@types/node@22.14.0)(@types/react@19.1.2)(fastify@5.2.2)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.39.0)(tsx@4.19.3)(typescript@5.8.3)(yaml@2.7.1)':
+  '@fastify/vue@1.0.0(@kitajs/ts-html-plugin@4.1.1(@kitajs/html@4.2.7)(typescript@5.8.3))(@types/node@22.14.0)(@types/react@19.1.2)(fastify@5.3.2)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.39.0)(tsx@4.19.3)(typescript@5.8.3)(yaml@2.7.1)':
     dependencies:
-      '@fastify/vite': 8.0.5(@kitajs/ts-html-plugin@4.1.1(@kitajs/html@4.2.7)(typescript@5.8.3))(@types/node@22.14.0)(@types/react@19.1.2)(fastify@5.2.2)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.39.0)(tsx@4.19.3)(typescript@5.8.3)(yaml@2.7.1)
+      '@fastify/vite': 8.0.5(@kitajs/ts-html-plugin@4.1.1(@kitajs/html@4.2.7)(typescript@5.8.3))(@types/node@22.14.0)(@types/react@19.1.2)(fastify@5.3.2)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.39.0)(tsx@4.19.3)(typescript@5.8.3)(yaml@2.7.1)
       acorn: 8.14.1
       acorn-walk: 8.3.4
       devalue: 5.1.1
@@ -8977,9 +8974,9 @@ snapshots:
       - typescript
       - yaml
 
-  '@fastify/vue@1.0.6(@kitajs/ts-html-plugin@4.1.1(@kitajs/html@4.2.7)(typescript@5.8.3))(@types/node@22.14.0)(@types/react@19.1.2)(fastify@5.2.2)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.39.0)(tsx@4.19.3)(typescript@5.8.3)(yaml@2.7.1)':
+  '@fastify/vue@1.0.6(@kitajs/ts-html-plugin@4.1.1(@kitajs/html@4.2.7)(typescript@5.8.3))(@types/node@22.14.0)(@types/react@19.1.2)(fastify@5.3.2)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.39.0)(tsx@4.19.3)(typescript@5.8.3)(yaml@2.7.1)':
     dependencies:
-      '@fastify/vite': 8.0.5(@kitajs/ts-html-plugin@4.1.1(@kitajs/html@4.2.7)(typescript@5.8.3))(@types/node@22.14.0)(@types/react@19.1.2)(fastify@5.2.2)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.39.0)(tsx@4.19.3)(typescript@5.8.3)(yaml@2.7.1)
+      '@fastify/vite': 8.0.5(@kitajs/ts-html-plugin@4.1.1(@kitajs/html@4.2.7)(typescript@5.8.3))(@types/node@22.14.0)(@types/react@19.1.2)(fastify@5.3.2)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.39.0)(tsx@4.19.3)(typescript@5.8.3)(yaml@2.7.1)
       acorn: 8.14.1
       acorn-walk: 8.3.4
       devalue: 5.1.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,7 +9,7 @@ catalog:
   '@vitejs/plugin-vue': ^5.2.3
   '@vitejs/plugin-react': ^4.4.1
   devalue: ^5.1.1
-  fastify: ^5.2.2
+  fastify: ^5.3.2
   oxlint: ^0.16.6
   react-dom: ^19.1.0
   react-router: ^7.5.1

--- a/starters/react-base/package.json
+++ b/starters/react-base/package.json
@@ -11,7 +11,7 @@
     "@fastify/one-line-logger": "^2.0.2",
     "@fastify/react": "latest",
     "@fastify/vite": "latest",
-    "fastify": "^5.2.2",
+    "fastify": "^5.3.2",
     "history": "^5.3.0",
     "minipass": "^7.1.2",
     "react": "^19.1.0",

--- a/starters/react-kitchensink/package.json
+++ b/starters/react-kitchensink/package.json
@@ -11,7 +11,7 @@
     "@fastify/one-line-logger": "^2.0.2",
     "@fastify/react": "workspace:^",
     "@fastify/vite": "workspace:^",
-    "fastify": "^5.2.2",
+    "fastify": "^5.3.2",
     "history": "^5.3.0",
     "minipass": "^7.1.2",
     "react": "^19.1.0",

--- a/starters/react-typescript/package.json
+++ b/starters/react-typescript/package.json
@@ -13,7 +13,7 @@
     "@fastify/one-line-logger": "^2.0.2",
     "@fastify/react": "workspace:^",
     "@fastify/vite": "workspace:^",
-    "fastify": "^5.2.2",
+    "fastify": "^5.3.2",
     "history": "^5.3.0",
     "minipass": "^7.1.2",
     "react": "^19.1.0",

--- a/starters/react-typescript/server.ts
+++ b/starters/react-typescript/server.ts
@@ -2,6 +2,10 @@ import Fastify from 'fastify'
 import FastifyVite from '@fastify/vite'
 import FastifyFormBody from '@fastify/formbody'
 
+interface Database {
+  todoList: string[]
+}
+
 const server = Fastify({
   logger: {
     transport: {
@@ -10,19 +14,19 @@ const server = Fastify({
   }
 })
 
-// @ts-ignore
+// @ts-ignore - pnpm module resolution issue
 await server.register(FastifyFormBody)
-// @ts-ignore
+// @ts-ignore - pnpm module resolution issue
 await server.register(FastifyVite, {
   // TODO handle via CLI path argument with proper resolve
   root: process.cwd(),
   renderer: '@fastify/react',
 })
 
-// @ts-ignore
+// @ts-ignore - pnpm module resolution issue
 await server.vite.ready()
 
-server.decorate('db', {
+server.decorate<Database>('db', {
   todoList: [
     'Do laundry',
     'Respond to emails',
@@ -30,15 +34,19 @@ server.decorate('db', {
   ]
 })
 
-server.put('/api/todo/items', (req, reply) => {
-  // @ts-ignore
-  server.db.todoList.push(req.body)
+server.put<{
+  Body: string
+}>('/api/todo/items', (req, reply) => {
+  const db = server.getDecorator<Database>('db')
+  db.todoList.push(req.body)
   reply.send({ ok: true })
 })
 
-server.delete('/api/todo/items', (req, reply) => {
-  // @ts-ignore
-  server.db.todoList.splice(req.body, 1)
+server.delete<{
+  Body: number
+}>('/api/todo/items', (req, reply) => {
+  const db = server.getDecorator<Database>('db')
+  db.todoList.splice(req.body, 1)
   reply.send({ ok: true })
 })
 

--- a/starters/react-typescript/server.ts
+++ b/starters/react-typescript/server.ts
@@ -14,16 +14,14 @@ const server = Fastify({
   }
 })
 
-// @ts-ignore - pnpm module resolution issue
 await server.register(FastifyFormBody)
-// @ts-ignore - pnpm module resolution issue
+
 await server.register(FastifyVite, {
   // TODO handle via CLI path argument with proper resolve
   root: process.cwd(),
   renderer: '@fastify/react',
 })
 
-// @ts-ignore - pnpm module resolution issue
 await server.vite.ready()
 
 server.decorate<Database>('db', {

--- a/starters/vue-base/package.json
+++ b/starters/vue-base/package.json
@@ -12,7 +12,7 @@
     "@fastify/one-line-logger": "^2.0.2",
     "@fastify/vite": "8.0.0",
     "@fastify/vue": "1.0.0",
-    "fastify": "^5.2.2",
+    "fastify": "^5.3.2",
     "unihead": "^0.8.0",
     "vue": "^3.5.13",
     "vue-router": "^4.5.0"

--- a/starters/vue-kitchensink/package.json
+++ b/starters/vue-kitchensink/package.json
@@ -12,7 +12,7 @@
     "@fastify/one-line-logger": "^2.0.2",
     "@fastify/vite": "8.0.0",
     "@fastify/vue": "1.0.0",
-    "fastify": "^5.2.2",
+    "fastify": "^5.3.2",
     "html-rewriter-wasm": "^0.4.1",
     "unihead": "^0.8.0",
     "vue": "^3.5.13",

--- a/starters/vue-typescript/package.json
+++ b/starters/vue-typescript/package.json
@@ -15,7 +15,7 @@
     "@fastify/one-line-logger": "^2.0.2",
     "@fastify/vite": "workspace:^",
     "@fastify/vue": "workspace:^",
-    "fastify": "^5.2.2",
+    "fastify": "^5.3.2",
     "html-rewriter-wasm": "^0.4.1",
     "unihead": "^0.8.0",
     "vue": "^3.5.13",


### PR DESCRIPTION
I've added type definitions to the React + TypeScript starter.

I don’t have much experience with `pnpm` and tend to avoid it, since managing type definitions through dependencies can get complicated. We should consider this carefully to avoid future issues.

I suggest opening an issue to address both typing and validation at the same time regarding payloads.
Example in the official demo:
https://github.com/fastify/demo/blob/main/src/routes/api/tasks/index.ts#L22