### PR TITLE
fix: question mark

### DIFF
--- a/packages/fastify-vite/plugin.mjs
+++ b/packages/fastify-vite/plugin.mjs
@@ -69,7 +69,7 @@ export function viteFastify({ spa, clientModule } = {}) {
       fastify.entryPaths = Object.fromEntries(
         Object.entries(resolvedConfig.environments)
           .map(([env, envConfig]) => {
-            if (envConfig.build.outDir) {
+            if (envConfig.build?.outDir) {
               fastify.outDirs[env] = envConfig.build.outDir
             }
             if (envConfig.build?.rollupOptions?.input?.index) {


### PR DESCRIPTION
Not sure why, but I ran into an issue because there was no `?` here when running `vitest` on CI in one of my projects.


```
TypeError: Cannot read properties of undefined (reading 'outDir')
    at file:///builds/path/to/my/repo/node_modules/@fastify/vite/plugin.mjs:72:33
    at Array.map (<anonymous>)
    at configResolved (file:///builds/path/to/my/repo/node_modules/@fastify/vite/plugin.mjs:71:12)
    at file:///builds/path/to/my/repo/node_modules/vite/dist/node/chunks/dep-CzJTQ5q7.js:666[98](https://gitlab.com/path/to/my/repo/-/jobs/9873519651#L98):67
    at Array.map (<anonymous>)
    at resolveConfig (file:///builds/path/to/my/repo/node_modules/vite/dist/node/chunks/dep-CzJTQ5q7.js:66698:53)
    at async _createServer (file:///builds/path/to/my/repo/node_modules/vite/dist/node/chunks/dep-CzJTQ5q7.js:63048:18)
    at async createViteServer (file:///builds/path/to/my/repo/node_modules/vitest/dist/chunks/cli-api.bwYuoT4p.js:[101](https://gitlab.com/path/to/my/repo/-/jobs/9873519651#L101)49:17)
    at async createVitest (file:///builds/path/to/my/repo/node_modules/vitest/dist/chunks/cli-api.bwYuoT4p.js:13130:17)
    at async prepareVitest (file:///builds/path/to/my/repo/node_modules/vitest/dist/chunks/cli-api.bwYuoT4p.js:13521:14)
```