### PR TITLE
[fastify-htmx]: Remove unused variables/parameters

### DIFF
--- a/packages/fastify-htmx/index.js
+++ b/packages/fastify-htmx/index.js
@@ -108,7 +108,7 @@ async function prepareClient(clientModule, scope, config) {
 }
 
 // The return value of this function gets registered as reply.html()
-export function createHtmlFunction(source, scope, config) {
+export function createHtmlFunction(source, _, config) {
   const htmlTemplate = config.createHtmlTemplateFunction(source)
   return function (ctx) {
     this.type('text/html')
@@ -117,7 +117,7 @@ export function createHtmlFunction(source, scope, config) {
   }
 }
 
-export function createRouteHandler({ client, route }, scope, config) {
+export function createRouteHandler({ client, route }, scope) {
   if (route.fragment) {
     return async (req, reply) => {
       req.route = route

--- a/packages/fastify-htmx/plugin.cjs
+++ b/packages/fastify-htmx/plugin.cjs
@@ -1,9 +1,8 @@
-const { readFileSync, existsSync } = require('fs')
-const { dirname, join, resolve } = require('path')
-const { fileURLToPath } = require('url')
+const { readFileSync, existsSync } = require('node:fs')
+const { resolve } = require('node:path')
 const inject = require('@rollup/plugin-inject')
 
-function viteFastifyHtmx(config = {}) {
+function viteFastifyHtmx() {
   const prefix = /^\/:/
   const virtualRoot = resolve(__dirname, 'virtual')
   const virtualModules = [

--- a/packages/fastify-htmx/virtual/layouts/default.jsx
+++ b/packages/fastify-htmx/virtual/layouts/default.jsx
@@ -1,6 +1,6 @@
 import { Suspense } from '@kitajs/html/suspense.js'
 // This file serves as a placeholder if no layout.jsx file is provided
 
-export default function Layout({ app, req, reply, children }) {
+export default function Layout({ children }) {
   return <Suspense>{children}</Suspense>
 }


### PR DESCRIPTION
💅 Removes a bunch of unused varibles/parameters and adds `node:` prefix where necessary.