### PR TITLE
fix: return reply in async handlers

### DIFF
--- a/examples/react-next-mini/renderer.js
+++ b/examples/react-next-mini/renderer.js
@@ -15,7 +15,7 @@ function createRoute ({ handler, errorHandler, route }, scope, config) {
   if (route.getServerSideProps) {
     // If getServerSideProps is provided, register JSON endpoint for it
     scope.get(`/json${route.path}`, async (req, reply) => {
-      reply.send(
+      return reply.send(
         await route.getServerSideProps({
           req,
           fetchJSON: scope.fetchJSON,

--- a/examples/vue-next-mini/renderer.js
+++ b/examples/vue-next-mini/renderer.js
@@ -23,7 +23,7 @@ async function createRoute ({ handler, errorHandler, route }, scope, config) {
   if (route.getServerSideProps) {
     // If getServerSideProps is provided, register JSON endpoint for it
     scope.get(`/json${route.path}`, async (req, reply) => {
-      reply.send(await route.getServerSideProps({
+      return reply.send(await route.getServerSideProps({
         req,
         ky: scope.ky
       }))

--- a/packages/fastify-react/routing.js
+++ b/packages/fastify-react/routing.js
@@ -140,7 +140,7 @@ export async function createRoute ({ client, errorHandler, route }, scope, confi
     scope.get(`/-/data${routePath}`, {
       onRequest,
       async handler (req, reply) {
-        reply.send(await route.getData(req.route))
+        return reply.send(await route.getData(req.route))
       },
     })
   }

--- a/packages/fastify-vue/routing.js
+++ b/packages/fastify-vue/routing.js
@@ -142,7 +142,7 @@ export async function createRoute ({ client, errorHandler, route }, scope, confi
     scope.get(`/-/data${routePath}`, {
       onRequest,
       async handler (req, reply) {
-        reply.send(await route.getData(req.route))
+        return reply.send(await route.getData(req.route))
       },
     })
   }


### PR DESCRIPTION
Fixes #292 by returning `reply` object from `async` Fastify handlers where it's missing.\
According to the Fastify [docs](https://fastify.dev/docs/latest/Reference/Routes/#async-await), `reply` must be returned from `async` handler to avoid race conditions.