### PR TITLE
Fix pathing for relative outDirs

### DIFF
--- a/.changeset/dirty-books-begin.md
+++ b/.changeset/dirty-books-begin.md
@@ -1,0 +1,5 @@
+---
+"@fastify/vite": patch
+---
+
+Fix pathing for relative outDirs in vite configs. #350

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,32 @@
+# Examples
+
+This directory contains examples demonstrating how to use `@fastify/vite` with various frameworks and configurations.
+
+## Dual Purpose
+
+These examples serve two purposes:
+
+1. **Usage Examples** — Reference implementations showing how to integrate Vite with Fastify for different use cases (React, Vue, SSR, SPA, TypeScript, etc.)
+
+2. **Integration Tests** — Examples with a `server.test.js` file run as part of CI to ensure `@fastify/vite` works correctly across different configurations
+
+## Running Tests
+
+To run all example integration tests:
+
+```bash
+pnpm test:examples
+```
+
+To run tests for a specific example:
+
+```bash
+cd examples/react-vanilla
+pnpm test
+```
+
+## Bug Reproductions
+
+Some examples exist primarily to reproduce and test specific issues:
+
+- `relative-outdir` — Reproduces [issue #303](https://github.com/fastify/fastify-vite/issues/303) (nested root with relative outDir)

--- a/examples/relative-outdir/README.md
+++ b/examples/relative-outdir/README.md
@@ -7,6 +7,7 @@ This example reproduces [issue #303](https://github.com/fastify/fastify-vite/iss
 When using a nested `root` directory with a relative `build.outDir`, the `vite.config.json` file is written to a location that the production runtime cannot find.
 
 **Configuration:**
+
 ```javascript
 export default {
   root: join(import.meta.dirname, 'src/client'),
@@ -18,6 +19,7 @@ export default {
 ```
 
 **Result:**
+
 - `vite.config.json` is written to: `dist/build/vite.config.json`
 - Production runtime looks in: `dist/vite.config.json`, then `client/dist/vite.config.json`
 - Neither path matches, causing startup failure
@@ -25,6 +27,7 @@ export default {
 ## Expected Behavior
 
 Once issue #303 is fixed, this example should:
+
 1. Build successfully with `pnpm build`
 2. Start in production with `pnpm start`
 3. Pass all integration tests

--- a/examples/relative-outdir/README.md
+++ b/examples/relative-outdir/README.md
@@ -1,0 +1,30 @@
+# relative-outdir
+
+This example reproduces [issue #303](https://github.com/fastify/fastify-vite/issues/303) and serves as an integration test to verify the fix.
+
+## The Bug
+
+When using a nested `root` directory with a relative `build.outDir`, the `vite.config.json` file is written to a location that the production runtime cannot find.
+
+**Configuration:**
+```javascript
+export default {
+  root: join(import.meta.dirname, 'src/client'),
+  build: {
+    outDir: '../../dist/build',
+  },
+  plugins: [viteFastify({ spa: true, useRelativePaths: true })],
+}
+```
+
+**Result:**
+- `vite.config.json` is written to: `dist/build/vite.config.json`
+- Production runtime looks in: `dist/vite.config.json`, then `client/dist/vite.config.json`
+- Neither path matches, causing startup failure
+
+## Expected Behavior
+
+Once issue #303 is fixed, this example should:
+1. Build successfully with `pnpm build`
+2. Start in production with `pnpm start`
+3. Pass all integration tests

--- a/examples/relative-outdir/package.json
+++ b/examples/relative-outdir/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@fastify-vite/example-relative-outdir",
+  "private": true,
+  "type": "module",
+  "description": "Demonstrates issue #303: vite.config.json path mismatch with relative outDir",
+  "scripts": {
+    "dev": "node server.js --dev",
+    "start": "NODE_ENV=production node server.js",
+    "build": "vite build --app",
+    "test": "node --test"
+  },
+  "dependencies": {
+    "@fastify/vite": "workspace:^",
+    "fastify": "catalog:"
+  },
+  "devDependencies": {
+    "vite": "catalog:"
+  }
+}

--- a/examples/relative-outdir/package.json
+++ b/examples/relative-outdir/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@fastify-vite/example-relative-outdir",
   "private": true,
-  "type": "module",
   "description": "Demonstrates issue #303: vite.config.json path mismatch with relative outDir",
+  "type": "module",
   "scripts": {
     "dev": "node server.js --dev",
     "start": "NODE_ENV=production node server.js",

--- a/examples/relative-outdir/server.js
+++ b/examples/relative-outdir/server.js
@@ -1,0 +1,24 @@
+import Fastify from 'fastify'
+import FastifyVite from '@fastify/vite'
+
+export async function main(dev) {
+  const server = Fastify()
+
+  await server.register(FastifyVite, {
+    root: import.meta.dirname,
+    dev: dev ?? process.argv.includes('--dev'),
+    spa: true,
+  })
+
+  server.get('/', (req, reply) => {
+    return reply.html()
+  })
+
+  await server.vite.ready()
+  return server
+}
+
+if (process.argv[1] === import.meta.filename) {
+  const server = await main()
+  await server.listen({ port: 3000 })
+}

--- a/examples/relative-outdir/server.test.js
+++ b/examples/relative-outdir/server.test.js
@@ -1,0 +1,16 @@
+import test from 'node:test'
+import { makeBuildTest, makeIndexTest } from '../test-factories.mjs'
+import { main } from './server.js'
+
+const cwd = import.meta.dirname
+
+// This test reproduces issue #303:
+// https://github.com/fastify/fastify-vite/issues/303
+//
+// When using a nested root with a relative outDir, the vite.config.json
+// is written to a location that the production runtime cannot find.
+
+test('relative-outdir (issue #303)', async (t) => {
+  await t.test('build production bundle', makeBuildTest({ cwd }))
+  await t.test('render index page in production', makeIndexTest({ main }))
+})

--- a/examples/relative-outdir/src/client/index.html
+++ b/examples/relative-outdir/src/client/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  </head>
+  <body>
+    <h1>Relative outDir Example</h1>
+    <p>This example demonstrates issue #303.</p>
+    <script type="module" src="/main.js"></script>
+  </body>
+</html>

--- a/examples/relative-outdir/src/client/main.js
+++ b/examples/relative-outdir/src/client/main.js
@@ -1,0 +1,1 @@
+console.log('Hello from relative-outdir example')

--- a/examples/relative-outdir/vite.config.js
+++ b/examples/relative-outdir/vite.config.js
@@ -1,0 +1,19 @@
+import { join } from 'node:path'
+import viteFastify from '@fastify/vite/plugin'
+
+// This configuration demonstrates issue #303:
+// When root is nested (src/client) and build.outDir uses a relative path,
+// the vite.config.json is written to a location that the production
+// runtime cannot find.
+//
+// Written to: dist/build/vite.config.json
+// Looking in: dist/vite.config.json (not found)
+//        then: client/dist/vite.config.json (not found)
+
+export default {
+  root: join(import.meta.dirname, 'src/client'),
+  build: {
+    outDir: '../../dist/build',
+  },
+  plugins: [viteFastify({ spa: true, useRelativePaths: true })],
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -340,6 +340,19 @@ importers:
         specifier: 'catalog:'
         version: 7.3.0(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.29.3)(tsx@4.21.0)(yaml@2.7.1)
 
+  examples/relative-outdir:
+    dependencies:
+      '@fastify/vite':
+        specifier: workspace:^
+        version: link:../../packages/fastify-vite
+      fastify:
+        specifier: 'catalog:'
+        version: 5.6.2
+    devDependencies:
+      vite:
+        specifier: 'catalog:'
+        version: 7.3.0(@types/node@22.19.3)(jiti@2.4.2)(lightningcss@1.29.3)(tsx@4.21.0)(yaml@2.7.1)
+
   examples/vue-hydration:
     dependencies:
       '@fastify/one-line-logger':
@@ -570,28 +583,6 @@ importers:
       vue-tsc:
         specifier: ^2.2.8
         version: 2.2.10(typescript@5.9.3)
-
-  packages/create-vite-app/templates/react-spa:
-    dependencies:
-      '@fastify/vite':
-        specifier: workspace:^
-        version: link:../../../fastify-vite
-      fastify:
-        specifier: 'catalog:'
-        version: 5.6.2
-      react:
-        specifier: catalog:react
-        version: 19.2.3
-      react-dom:
-        specifier: catalog:react
-        version: 19.2.3(react@19.2.3)
-    devDependencies:
-      '@vitejs/plugin-react':
-        specifier: catalog:react
-        version: 5.1.2(vite@7.3.0(@types/node@22.19.3)(jiti@2.4.2)(lightningcss@1.29.3)(tsx@4.21.0)(yaml@2.7.1))
-      vite:
-        specifier: 'catalog:'
-        version: 7.3.0(@types/node@22.19.3)(jiti@2.4.2)(lightningcss@1.29.3)(tsx@4.21.0)(yaml@2.7.1)
 
   packages/fastify-htmx:
     dependencies:


### PR DESCRIPTION
Fixes #303 

Using relative paths in Vite config's `build.outDir` should now accurately discover the `vite.config.json` file built by the vite plugin.