### PR TITLE
Add `key` and `meta` to route mapping.

### DIFF
--- a/.changeset/tame-hounds-battle.md
+++ b/.changeset/tame-hounds-battle.md
@@ -1,0 +1,5 @@
+---
+"@fastify/vue": minor
+---
+
+Added `key` and `meta` to route mapping

--- a/docs/vue/route-context.md
+++ b/docs/vue/route-context.md
@@ -279,7 +279,7 @@ Value of the current route module's `clientOnly` export.
 </td>
 <td>
 
-Disables cleint-side rendering (ships static markup).
+Disables client-side rendering (ships static markup).
 
 </td>
 </tr>

--- a/docs/vue/router-setup.md
+++ b/docs/vue/router-setup.md
@@ -28,6 +28,14 @@ export default import.meta.glob('/pages/**/*.vue')
 
 To change the location where routes are loaded from, just place a `routes.js` file at your Vite project's root directory and `@fastify/vue/plugin` will automatically recognize it and use it instead.
 
+### Route customization
+
+You can override the virtual `index.js` to provide your own `createRoutes` function. This will allow you to construct routes however you want to.
+If you have multiple routes with the same `path`, you can supply a `key` in the route object instead (`en__index`, `fr__index` for example). You can also supply a `meta` object for the route, this gets passed to the vue router.
+
+This allows for functionality like per domain/locale routing by setting the key to something like `${domain}__route_name` or `${locale}__route_name` like in the example above.  
+_Note that this also requires you to override `create.js` and provide your own route matching._
+
 ## Dynamic parameters
 
 Dynamic route parameters uses `[param]` for a singular parameter and `[param+]` for wildcard routes.

--- a/packages/fastify-vue/context.js
+++ b/packages/fastify-vue/context.js
@@ -24,6 +24,8 @@ export default class RouteContext {
     // Populated
     this.head = {}
     this.data = route.data
+    this.key = route.key
+    this.meta = route.meta
     this.state = null
     // Route settings
     this.layout = route.layout
@@ -49,6 +51,8 @@ export default class RouteContext {
     return {
       state: this.state,
       data: this.data,
+      key: this.key,
+      meta: this.meta,
       head: this.head,
       layout: this.layout,
       getMeta: this.getMeta,

--- a/packages/fastify-vue/rendering.js
+++ b/packages/fastify-vue/rendering.js
@@ -6,7 +6,7 @@ import { createHtmlTemplates } from './templating.js'
 
 export async function createRenderFunction({ routes, create }) {
   // Used when hydrating Vue Router on the client
-  const routeMap = Object.fromEntries(routes.map((_) => [_.path, _]))
+  const routeMap = Object.fromEntries(routes.map((_) => [_.key, _]))
   // Registered as reply.render()
   return function () {
     if (this.request.route.streaming) {

--- a/packages/fastify-vue/routing.js
+++ b/packages/fastify-vue/routing.js
@@ -41,7 +41,7 @@ export async function createRoute({ client, errorHandler, route }, scope, config
   }
 
   // Used when hydrating Vue Router on the client
-  const routeMap = Object.fromEntries(client.routes.map((_) => [_.path, _]))
+  const routeMap = Object.fromEntries(client.routes.map((_) => [_.key, _]))
 
   // Extend with route context initialization module
   RouteContext.extend(client.context)
@@ -122,7 +122,7 @@ export async function createRoute({ client, errorHandler, route }, scope, config
   }
 
   // Replace wildcard routes with Fastify compatible syntax
-  const routePath = route.path.replace(/:\w[\w-]*\+/, '*')
+  const routePath = route.path.replace(/:\w[\w-]*\+.*/, '*')
 
   unshiftHook(route, 'onRequest', onRequest)
   unshiftHook(route, 'preHandler', preHandler)
@@ -137,7 +137,8 @@ export async function createRoute({ client, errorHandler, route }, scope, config
 
   if (route.getData) {
     // If getData is provided, register JSON endpoint for it
-    scope.get(`/-/data${routePath}`, {
+    const dataPath = (route.dataPath ?? route.path).replace(/:\w[\w-]*\+.*/, '*')
+    scope.get(`/-/data${dataPath}`, {
       onRequest,
       async handler(req, reply) {
         return reply.send(await route.getData(req.route))

--- a/packages/fastify-vue/server.js
+++ b/packages/fastify-vue/server.js
@@ -6,6 +6,7 @@ class Routes extends Array {
       return {
         id: route.id,
         path: route.path,
+        key: route.key,
         name: route.name,
         layout: route.layout,
         getData: !!route.getData,
@@ -28,6 +29,7 @@ export async function createRoutes(fromPromise, { param } = { param: /\[([.\w]+\
             id: routeDef.path,
             name: routeDef.path ?? routeModule.path,
             path: routeDef.path ?? routeModule.path,
+            key: routeDef.path ?? routeModule.path,
             ...routeModule,
           }
         }),
@@ -59,10 +61,12 @@ export async function createRoutes(fromPromise, { param } = { param: /\[([.\w]+\
                 .replace(param, (_, m) => `:${m}`)
                 // Replace '/index' with '/'
                 .replace(/\/index$/, '/')
-                // Remove trailing slashs
+                // Remove trailing slashes
                 .replace(/(.+)\/+$/, (...m) => m[1]),
             ...routeModule,
           }
+
+          route.key = route.path
 
           if (route.name === '') {
             route.name = 'catch-all'

--- a/packages/fastify-vue/virtual-ts/mount.ts
+++ b/packages/fastify-vue/virtual-ts/mount.ts
@@ -7,7 +7,7 @@ import * as root from '$app/root.vue'
 async function mountApp(...targets) {
   const ctxHydration = await extendContext(window.route, context)
   const resolvedRoutes = await hydrateRoutes(routes)
-  const routeMap = Object.fromEntries(resolvedRoutes.map((route) => [route.path, route]))
+  const routeMap = Object.fromEntries(resolvedRoutes.map((route) => [route.key, route]))
   const { instance, router } = await create({
     ctxHydration,
     routes: window.routes,

--- a/packages/fastify-vue/virtual/mount.js
+++ b/packages/fastify-vue/virtual/mount.js
@@ -7,7 +7,7 @@ import * as root from '$app/root.vue'
 async function mountApp(...targets) {
   const ctxHydration = await extendContext(window.route, context)
   const resolvedRoutes = await hydrateRoutes(routes)
-  const routeMap = Object.fromEntries(resolvedRoutes.map((route) => [route.path, route]))
+  const routeMap = Object.fromEntries(resolvedRoutes.map((route) => [route.key, route]))
   const { instance, router } = await create({
     ctxHydration,
     routes: window.routes,


### PR DESCRIPTION
This allows the user to override `routing.js` to provide more complex routes (i18n for example) where the key(s) might be `en_index`, `fr_index` instead of the path. Also added a `dataPath` property that allows the user to customize the path used, defaults to the `routePath`.

Also fixes the wildcard rewrite to handle complex client vue routes such as `/categories/:slug+/index.html` which fastify doesn't handle, so it needs to be rewritten to `/categories/*`.
