### PR TITLE
TypeScript Phase 2: build scaffolding for @fastify/vite

### DIFF
--- a/packages/fastify-vite/TS_CONVERSION_PLAN.md
+++ b/packages/fastify-vite/TS_CONVERSION_PLAN.md
@@ -46,7 +46,7 @@ Use this at the end of each phase:
 
 By the end of this phase, there should be no more JavaScript files in the package root.
 
-## Phase 2: TypeScript build scaffolding (no runtime change)
+## Phase 2: TypeScript build scaffolding (no runtime change) (completed)
 
 8. Update the existing `tsconfig.json` to cover runtime sources with `declaration: true`, `declarationMap: true`, `sourceMap: true`, `emitDeclarationOnly: false`, and `outDir: dist/`.
 9. Enable `allowJs: true` and `checkJs: false` initially to let TS compile existing JS as a no-op.

--- a/packages/fastify-vite/package.json
+++ b/packages/fastify-vite/package.json
@@ -52,6 +52,7 @@
     "access": "public"
   },
   "scripts": {
+    "build": "tsc",
     "test": "vitest run --no-file-parallelism && vitest --typecheck.only --run"
   },
   "dependencies": {

--- a/packages/fastify-vite/tsconfig.json
+++ b/packages/fastify-vite/tsconfig.json
@@ -2,7 +2,17 @@
   "compilerOptions": {
     "target": "esnext",
     "lib": ["ES2020"],
-    "module": "NodeNext"
+    "module": "NodeNext",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "emitDeclarationOnly": false,
+    "outDir": "dist",
+    "allowJs": true,
+    "checkJs": false,
+    "rootDir": "src",
+    "skipLibCheck": true
   },
-  "include": ["types/*.test-d.ts"]
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.test.js", "src/**/*.test.mjs", "src/**/*.test.cjs"]
 }


### PR DESCRIPTION
- Updated tsconfig.json with declaration, sourceMap, outDir to dist/
- Enabled allowJs and checkJs: false for JS compilation
- Added rootDir: src and skipLibCheck: true
- Added build script to package.json (tsc)
- Excluded test files from TypeScript compilation
- Marked Phase 2 as completed in TS_CONVERSION_PLAN.md