### PR TITLE
TypeScript Phase 5: Leaf conversions

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -4,6 +4,7 @@
     "correctness": "error"
   },
   "rules": {
+    "import/extensions": ["error", "always", { "ignorePackages": true }],
     "no-unused-vars": "warn"
   }
 }

--- a/packages/fastify-vite/TS_CONVERSION_PLAN.md
+++ b/packages/fastify-vite/TS_CONVERSION_PLAN.md
@@ -71,44 +71,47 @@ By the end of this phase, there should be no more JavaScript files in the packag
 18. Update `.github/workflows/integration-tests.yml` to run `pnpm build` before `pnpm test:examples`.
 19. From this phase onward, always run `pnpm build` before `pnpm test:examples`.
 
-## Phase 5: Incremental file conversions (small, low-risk first)
+## Phase 5: Leaf conversions (no internal dependencies)
 
-20. Convert `utils.js` to `utils.ts`, moving types from `types/utils.d.ts` into the source.
-21. Convert `html.js` to `html.ts` and ensure any DOM/HTML types are explicit.
-22. Convert `setup.js` to TS, adding minimal type annotations for options/config objects.
+20. Convert `html.js` to `html.ts` and ensure any DOM/HTML types are explicit.
+21. Confirm `ioutils.cts` is stable as the base internal utility module (no change unless adding types).
+22. Convert `setup.js` to `setup.ts`, adding minimal type annotations for options/config objects.
+23. Convert `utils.js` to `utils.ts`, moving types from `types/utils.d.ts` into the source.
 
-## Phase 6: Core entry points and plugin surface
+## Phase 6: Config and mode conversions (depend on leaf modules)
 
-23. Convert `index.js` to `index.ts`, moving types from `types/index.d.ts` into the source.
-24. Convert `plugin.mjs` to `plugin.mts`, moving types from `types/plugin.d.ts` into the source.
-25. Convert `ioutils.cjs` to `ioutils.cts`, ensuring CJS interop is preserved (temporary until ESM-only phase).
-26. Delay converting `config.js`, `mode/development.js`, and `mode/production.js` until after the main surface is stable.
+24. Convert `config.js` to TS, adding minimal type annotations for options/config objects.
+25. Convert `mode/development.js` to TS, keeping runtime behavior unchanged.
+26. Convert `mode/production.js` to TS, keeping runtime behavior unchanged.
 
-## Phase 7: Types consolidation
+## Phase 7: Entry points and plugin surface (depend on config/mode)
 
-27. Verify emitted `.d.ts` files in `dist/` are compatible with existing consumers.
-28. Update `package.json` `types` and `exports` `types` entries to point to emitted declarations in `dist/` (keep handwritten files temporarily).
+27. Convert `plugin.mjs` to `plugin.mts`, moving types from `types/plugin.d.ts` into the source.
+28. Convert `index.js` to `index.ts`, moving types from `types/index.d.ts` into the source.
 
-## Phase 8: Types cleanup and remaining runtime conversions
+## Phase 8: Types consolidation
 
-29. Remove the handwritten `types/*.d.ts` files once `exports` `types` entries point to `dist/`.
-30. Convert `config.js` to TS, adding minimal type annotations for options/config objects.
-31. Convert `mode/development.js` and `mode/production.js` to TS, keeping runtime behavior unchanged.
+29. Verify emitted `.d.ts` files in `dist/` are compatible with existing consumers.
+30. Update `package.json` `types` and `exports` `types` entries to point to emitted declarations in `dist/` (keep handwritten files temporarily).
 
-## Phase 9: Tests, fixtures, and cleanup
+## Phase 9: Types cleanup
+
+31. Remove the handwritten `types/*.d.ts` files once `exports` `types` entries point to `dist/`.
+
+## Phase 10: Tests, fixtures, and cleanup
 
 32. Verify unit tests import from `src/` (relative paths) and integration tests (`examples/`) import via `@fastify/vite` (resolved through package exports to `dist/`).
 33. Remove obsolete JS sources once TS build is the sole runtime source.
 34. Add a changeset if package behavior or public exports change.
 
-## Phase 10: Shift to ESM-only sources and outputs
+## Phase 11: Shift to ESM-only sources and outputs
 
 35. Set package `type: "module"` and emit only `.js` ESM outputs.
 36. Rename any `.mts`/`.cts` sources to `.ts` and update imports/exports accordingly.
 37. Update `package.json` `main`/`exports` to ESM-only paths and remove CJS mappings.
 38. Replace all `require` usage with `import` across the package and tests for ESM consistency (keep CJS fixtures for historical/compat coverage).
 
-## Phase 11: Follow-up hardening
+## Phase 12: Follow-up hardening
 
 39. Tighten `noImplicitAny`/`strict` settings only after the TS migration is stable.
 40. Add type-level tests to replace or extend current `types/*.test-d.ts` coverage.

--- a/packages/fastify-vite/src/config.js
+++ b/packages/fastify-vite/src/config.js
@@ -11,7 +11,7 @@ const {
   stat,
   read,
 } = require('./ioutils.cts')
-const { createHtmlTemplateFunction } = require('./html.js')
+const { createHtmlTemplateFunction } = require('./html.ts')
 
 function createClientEnvironment(dev, outDir) {
   return {

--- a/packages/fastify-vite/src/html.test.js
+++ b/packages/fastify-vite/src/html.test.js
@@ -1,6 +1,6 @@
 import { readFile } from 'node:fs/promises'
 import { describe, expect, test } from 'vitest'
-import { createHtmlTemplateFunction } from './html.js'
+import { createHtmlTemplateFunction } from './html.ts'
 
 describe('createHtmlTemplateFunction', () => {
   test('replaces comments without spaces <!-- element -->', async () => {

--- a/packages/fastify-vite/src/ioutils.cts
+++ b/packages/fastify-vite/src/ioutils.cts
@@ -1,15 +1,17 @@
-// @ts-nocheck
-const { existsSync, lstatSync } = require('node:fs')
-const { writeFile, readFile } = require('node:fs/promises')
-const { isAbsolute, join, resolve, parse, dirname, basename, sep } = require('node:path')
-const { ensureDir, remove } = require('fs-extra')
-const klaw = require('klaw')
+import { existsSync, lstatSync, Stats } from 'node:fs'
+import { writeFile, readFile } from 'node:fs/promises'
+import { isAbsolute, join, resolve, parse, dirname, basename, sep } from 'node:path'
+import { ensureDir, remove } from 'fs-extra'
+import klaw from 'klaw'
 
-function resolveIfRelative(p, root) {
+export function resolveIfRelative(p: string, root: string, f: string): string {
   return isAbsolute(p) ? p : resolve(root, p)
 }
 
-async function* walk(dir, ignorePatterns = []) {
+export async function* walk(
+  dir: string,
+  ignorePatterns: RegExp[] = [],
+): AsyncIterable<{ stats: Stats; path: string }> {
   const sliceAt = dir.length + (dir.endsWith('/') ? 0 : 1)
   for await (const match of klaw(dir)) {
     const pathEntry = match.path.slice(sliceAt)
@@ -23,20 +25,18 @@ async function* walk(dir, ignorePatterns = []) {
   }
 }
 
-module.exports = {
+export {
   parse,
   join,
   resolve,
-  resolveIfRelative,
-  walk,
   dirname,
   basename,
   remove,
   isAbsolute,
   sep,
-  write: writeFile,
-  read: readFile,
-  exists: existsSync,
-  stat: lstatSync,
-  ensure: ensureDir,
+  writeFile as write,
+  readFile as read,
+  existsSync as exists,
+  lstatSync as stat,
+  ensureDir as ensure,
 }

--- a/packages/fastify-vite/src/setup.ts
+++ b/packages/fastify-vite/src/setup.ts
@@ -1,7 +1,16 @@
-const { parse: parsePath } = require('node:path')
-const { join, walk, ensure, exists, write, read } = require('./ioutils.cts')
+import { parse as parsePath } from 'node:path'
+import { join, walk, ensure, exists, write, read } from './ioutils.cts'
 
-async function ejectBlueprint(base, { root, renderer }) {
+export interface RendererInfo {
+  path: string
+}
+
+export interface SetupOptions {
+  root: string
+  renderer: RendererInfo
+}
+
+async function ejectBlueprint(base: string, { root, renderer }: SetupOptions): Promise<void> {
   await ensure(root)
   for await (const { stats, path } of walk(join(renderer.path, 'blueprint'))) {
     const filePath = join(root, path)
@@ -14,7 +23,7 @@ async function ejectBlueprint(base, { root, renderer }) {
   }
 }
 
-async function ensureConfigFile(base, { root, renderer }) {
+async function ensureConfigFile(base: string, { renderer }: SetupOptions): Promise<string> {
   const sourcePath = join(renderer.path, 'config.mjs')
   const targetPath = join(base, 'vite.config.js')
   if (exists(sourcePath) && !exists(targetPath)) {
@@ -24,5 +33,5 @@ async function ensureConfigFile(base, { root, renderer }) {
   return targetPath
 }
 
-module.exports = { ensureConfigFile, ejectBlueprint }
-module.exports.default = module.exports
+export { ensureConfigFile, ejectBlueprint }
+export default { ensureConfigFile, ejectBlueprint }

--- a/packages/fastify-vite/src/utils.js
+++ b/packages/fastify-vite/src/utils.js
@@ -1,4 +1,4 @@
-const { ensureConfigFile, ejectBlueprint } = require('./setup.js')
+const { ensureConfigFile, ejectBlueprint } = require('./setup.ts')
 const { createHtmlTemplateFunction } = require('./html.ts')
 
 module.exports.createHtmlTemplateFunction = createHtmlTemplateFunction

--- a/packages/fastify-vite/src/utils.js
+++ b/packages/fastify-vite/src/utils.js
@@ -1,6 +1,0 @@
-const { ensureConfigFile, ejectBlueprint } = require('./setup.ts')
-const { createHtmlTemplateFunction } = require('./html.ts')
-
-module.exports.createHtmlTemplateFunction = createHtmlTemplateFunction
-module.exports.ensureConfigFile = ensureConfigFile
-module.exports.ejectBlueprint = ejectBlueprint

--- a/packages/fastify-vite/src/utils.js
+++ b/packages/fastify-vite/src/utils.js
@@ -1,5 +1,5 @@
 const { ensureConfigFile, ejectBlueprint } = require('./setup.js')
-const { createHtmlTemplateFunction } = require('./html.js')
+const { createHtmlTemplateFunction } = require('./html.ts')
 
 module.exports.createHtmlTemplateFunction = createHtmlTemplateFunction
 module.exports.ensureConfigFile = ensureConfigFile

--- a/packages/fastify-vite/src/utils.ts
+++ b/packages/fastify-vite/src/utils.ts
@@ -1,0 +1,5 @@
+import { ensureConfigFile, ejectBlueprint } from './setup.ts'
+import { createHtmlTemplateFunction } from './html.ts'
+
+export { createHtmlTemplateFunction, ensureConfigFile, ejectBlueprint }
+export default { createHtmlTemplateFunction, ensureConfigFile, ejectBlueprint }

--- a/packages/fastify-vite/tsconfig.json
+++ b/packages/fastify-vite/tsconfig.json
@@ -1,20 +1,21 @@
 {
   "compilerOptions": {
-    "target": "esnext",
+    "allowJs": true,
+    "allowImportingTsExtensions": true,
+    "checkJs": false,
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": false,
     "lib": ["ES2020"],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
-    "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
-    "emitDeclarationOnly": false,
     "outDir": "dist",
-    "allowJs": true,
-    "checkJs": false,
+    "rewriteRelativeImportExtensions": true,
     "rootDir": "src",
     "skipLibCheck": true,
-    "rewriteRelativeImportExtensions": true
+    "sourceMap": true,
+    "target": "esnext",
   },
   "include": ["src/**/*"],
-  "exclude": ["src/**/*.test.js", "src/**/*.test.mts", "src/**/*.test.cjs"]
+  "exclude": ["src/**/*.test.js", "src/**/*.test.mts", "src/**/*.test.cjs"],
 }

--- a/packages/fastify-vite/tsconfig.json
+++ b/packages/fastify-vite/tsconfig.json
@@ -14,8 +14,8 @@
     "rootDir": "src",
     "skipLibCheck": true,
     "sourceMap": true,
-    "target": "esnext",
+    "target": "esnext"
   },
   "include": ["src/**/*"],
-  "exclude": ["src/**/*.test.js", "src/**/*.test.mts", "src/**/*.test.cjs"],
+  "exclude": ["src/**/*.test.js", "src/**/*.test.mts", "src/**/*.test.cjs"]
 }


### PR DESCRIPTION
20. Convert `html.js` to `html.ts` and ensure any DOM/HTML types are explicit.
21. Confirm `ioutils.cts` is stable as the base internal utility module (no change unless adding types).
22. Convert `setup.js` to `setup.ts`, adding minimal type annotations for options/config objects.
23. Convert `utils.js` to `utils.ts`, moving types from `types/utils.d.ts` into the source.