### PR TITLE
TypeScript Phase 13: Production typing

### DIFF
--- a/packages/fastify-vite/TS_CONVERSION_PLAN.md
+++ b/packages/fastify-vite/TS_CONVERSION_PLAN.md
@@ -174,26 +174,38 @@ By the end of this phase, there should be no more JavaScript files in the packag
     }
     ```
 
-## Phase 13: Production typing
+## Phase 13: Production typing (completed)
 
-43. Remove prod-mode `any` for output directories and assets access by narrowing `config.vite` with a discriminated union so `packages/fastify-vite/src/mode/production.ts:56` and `packages/fastify-vite/src/mode/production.ts:62` stop using `as ResolvedConfig as any`.
-44. Add `prefix?: string` to `ConfigOptions`/`FastifyViteOptions` and use it to remove `(config as any).prefix` at `packages/fastify-vite/src/mode/production.ts:72`.
-45. Type `prepareClient`/`createRenderFunction` usage in `packages/fastify-vite/src/mode/production.ts:112`, `packages/fastify-vite/src/mode/production.ts:120`, and `packages/fastify-vite/src/mode/production.ts:124` with `ClientEntries`/`ClientModule` so `client` and `routes` return types are no longer cast.
-46. Switch `RuntimeConfig.vite` to a discriminated union so dev/prod paths narrow safely:
+43. Remove prod-mode `any` for output directories and assets access by narrowing `config.vite` with a discriminated union so `packages/fastify-vite/src/mode/production.ts:56` and `packages/fastify-vite/src/mode/production.ts:62` stop using `as ResolvedConfig as any`. (completed)
+    - Created `DevRuntimeConfig` and `ProdRuntimeConfig` discriminated union types.
+    - Updated `production.ts` to use `ProdRuntimeConfig` and access `vite.build.outDir`/`vite.build.assetsDir` without `as any` casts.
+    - Updated `development.ts` to use `DevRuntimeConfig` and remove unnecessary `as ResolvedConfig` casts.
+44. Add `prefix?: string` to `ConfigOptions`/`FastifyViteOptions` and use it to remove `(config as any).prefix` at `packages/fastify-vite/src/mode/production.ts:72`. (completed)
+    - Added `prefix?: string` to `ConfigOptions` in `types.ts`.
+    - Added `prefix?: string` to `FastifyViteOptions` in `index.ts`.
+    - Updated `production.ts` to use `config.prefix` directly.
+45. Type `prepareClient`/`createRenderFunction` usage in `packages/fastify-vite/src/mode/production.ts:112`, `packages/fastify-vite/src/mode/production.ts:120`, and `packages/fastify-vite/src/mode/production.ts:124` with `ClientEntries`/`ClientModule` so `client` and `routes` return types are no longer cast. (completed)
+    - Updated `prepareClient` return type in `ConfigOptions` from `Promise<unknown>` to `Promise<ClientModule | undefined>`.
+    - Updated `production.ts` to explicitly type `client` as `ClientModule | undefined`.
+    - Removed `as any` casts from `prepareClient` and `createRenderFunction` calls.
+    - Removed unused `viteConfig` parameter from `loadBundle` helper function.
+46. Switch `RuntimeConfig.vite` to a discriminated union so dev/prod paths narrow safely: (completed)
 
     ```ts
-    interface DevRuntimeConfig extends ConfigOptions {
+    interface DevRuntimeConfig extends BaseRuntimeConfig {
       dev: true
       vite: ExtendedResolvedViteConfig
     }
 
-    interface ProdRuntimeConfig extends ConfigOptions {
+    interface ProdRuntimeConfig extends BaseRuntimeConfig {
       dev: false
-      vite: SerializableViteConfig
+      vite: ExtendedResolvedViteConfig | SerializableViteConfig
     }
 
     export type RuntimeConfig = DevRuntimeConfig | ProdRuntimeConfig
     ```
+
+    - Exported `DevRuntimeConfig` and `ProdRuntimeConfig` types for consumers.
 
 ## Phase 14: Type imports and consolidation
 

--- a/packages/fastify-vite/src/index.ts
+++ b/packages/fastify-vite/src/index.ts
@@ -11,7 +11,9 @@ import type {
   CreateRoute,
   CreateRouteHandler,
   DecoratedReply,
+  DevRuntimeConfig,
   HtmlFunction,
+  ProdRuntimeConfig,
   RenderContext,
   RenderFunction,
   RenderResult,
@@ -29,7 +31,9 @@ export type {
   CreateRoute,
   CreateRouteHandler,
   DecoratedReply,
+  DevRuntimeConfig,
   HtmlFunction,
+  ProdRuntimeConfig,
   RenderContext,
   RenderFunction,
   RenderResult,
@@ -149,6 +153,11 @@ export interface FastifyViteOptions extends Partial<RendererOption> {
    * If a relative path is provided, it is resolved relative to the app root.
    */
   distDir?: string
+  /**
+   * URL prefix for static asset routes in production mode.
+   * Use this when mounting @fastify/vite under a path prefix.
+   */
+  prefix?: string
 }
 
 interface ModeModule {

--- a/packages/fastify-vite/src/mode/development.ts
+++ b/packages/fastify-vite/src/mode/development.ts
@@ -14,8 +14,8 @@ import type {
   ClientEntries,
   ClientModule,
   DecoratedReply,
+  DevRuntimeConfig,
   RouteDefinition,
-  RuntimeConfig,
 } from '../types.ts'
 
 export const hot = Symbol('hotModuleReplacementProxy')
@@ -73,14 +73,14 @@ function hasIterableRoutes(
   )
 }
 
-export async function setup(this: SetupContext, config: RuntimeConfig) {
+export async function setup(this: SetupContext, config: DevRuntimeConfig) {
   const loadEntryModulePaths = async (): Promise<Record<string, string> | null> => {
     if (config.spa) {
       return null
     }
     const entryModulePaths: Record<string, string> = {}
 
-    const viteConfig = config.vite as ResolvedConfig
+    const viteConfig = config.vite
 
     if (!hasPlugin(viteConfig, 'vite-fastify')) {
       throw new Error("@fastify/vite's Vite plugin not registered")
@@ -140,7 +140,7 @@ export async function setup(this: SetupContext, config: RuntimeConfig) {
   }
   const devServerOptions = mergeConfig(
     defineConfig(baseConfig) as UserConfig,
-    config.vite as UserConfig,
+    config.vite as unknown as UserConfig,
   ) as InlineConfig
 
   this.devServer = await createServer(devServerOptions)
@@ -205,7 +205,7 @@ export async function setup(this: SetupContext, config: RuntimeConfig) {
         }
       }
     }
-    const viteConfig = config.vite as ResolvedConfig
+    const viteConfig = config.vite
     const indexHtmlPath = join(viteConfig.root, 'index.html')
     const indexHtml = await readFile(indexHtmlPath, 'utf8')
     const transformedHtml = await this.devServer.transformIndexHtml(req.url, indexHtml)

--- a/packages/fastify-vite/src/types.ts
+++ b/packages/fastify-vite/src/types.ts
@@ -166,13 +166,16 @@ export interface ConfigOptions {
 
   virtualModulePrefix: string
 
+  /** URL prefix for static asset routes in production mode */
+  prefix?: string
+
   prepareServer: (scope: FastifyInstance, config: RuntimeConfig) => void
 
   prepareClient: (
     entries: ClientEntries,
     scope: FastifyInstance,
     config: RuntimeConfig,
-  ) => Promise<unknown>
+  ) => Promise<ClientModule | undefined>
 
   createHtmlTemplateFunction: CreateHtmlTemplateFunction
 
@@ -185,7 +188,21 @@ export interface ConfigOptions {
   createErrorHandler: CreateErrorHandler
 }
 
-export interface RuntimeConfig extends ConfigOptions {
+interface BaseRuntimeConfig extends Omit<ConfigOptions, 'dev' | 'vite'> {
   hasRenderFunction?: boolean
   ssrManifest?: unknown
 }
+
+/** Runtime config in development mode with full Vite resolved config */
+export interface DevRuntimeConfig extends BaseRuntimeConfig {
+  dev: true
+  vite: ExtendedResolvedViteConfig
+}
+
+/** Runtime config in production mode with serialized Vite config from vite.config.json */
+export interface ProdRuntimeConfig extends BaseRuntimeConfig {
+  dev: false
+  vite: ExtendedResolvedViteConfig | SerializableViteConfig
+}
+
+export type RuntimeConfig = DevRuntimeConfig | ProdRuntimeConfig


### PR DESCRIPTION
- Create DevRuntimeConfig and ProdRuntimeConfig discriminated union types
- Add prefix property to ConfigOptions and FastifyViteOptions
- Remove as any casts in production.ts for vite config access
- Type prepareClient return as ClientModule | undefined
- Update development.ts to use DevRuntimeConfig
- Export new discriminated union types for consumers
