### PR TITLE
TypeScript Phase 14: Type imports and consolidation

### DIFF
--- a/packages/fastify-vite/TS_CONVERSION_PLAN.md
+++ b/packages/fastify-vite/TS_CONVERSION_PLAN.md
@@ -207,12 +207,28 @@ By the end of this phase, there should be no more JavaScript files in the packag
 
     - Exported `DevRuntimeConfig` and `ProdRuntimeConfig` types for consumers.
 
-## Phase 14: Type imports and consolidation
+## Phase 14: Type imports and consolidation (completed)
 
-47. Replace local Vite config loader types with Vite exports (`UserConfigExport`, `UserConfigFn`) in `packages/fastify-vite/src/config/vite-config.ts:7`.
-48. Replace `bundle.manifest` types with `Manifest` in `packages/fastify-vite/src/types.ts:32` and `packages/fastify-vite/src/types.ts:38`.
-49. Replace `ssrManifest` with `Manifest` (or `Manifest | undefined`) in `packages/fastify-vite/src/types.ts:190`.
-50. Consolidate duplicate and overlapping types by merging `BundleInfo`/`Bundle` (`packages/fastify-vite/src/types.ts:31`, `packages/fastify-vite/src/types.ts:37`), moving `RouteType`/`Ctx`/`RendererOption` from `packages/fastify-vite/src/index.ts` into `packages/fastify-vite/src/types.ts`, and replacing inline args with `CreateRouteArgs` (`packages/fastify-vite/src/config/defaults.ts:86`, `packages/fastify-vite/src/types.ts:129`).
+47. Replace local Vite config loader types with Vite exports (`UserConfigExport`, `UserConfigFn`) in `packages/fastify-vite/src/config/vite-config.ts:7`. (completed)
+    - Imported `ConfigEnv` and `UserConfigExport` from Vite.
+    - Created `ExtendedUserConfigFn` type that uses Vite's `ConfigEnv`.
+    - Updated `UserConfigModule` to include `UserConfigExport`.
+    - Changed `ssrBuild` to `isSsrBuild` to align with Vite's `ConfigEnv` interface.
+48. Replace `bundle.manifest` types with `Manifest` in `packages/fastify-vite/src/types.ts:32` and `packages/fastify-vite/src/types.ts:38`. (completed)
+    - Imported `Manifest` from Vite.
+    - Updated `BundleInfo.manifest` to use `Manifest` type.
+    - Merged `Bundle` as a deprecated type alias for `BundleInfo`.
+    - Fixed `bundle.ts` to use empty object `{}` instead of array `[]` for dev mode manifest.
+49. Replace `ssrManifest` with `Manifest` (or `Manifest | undefined`) in `packages/fastify-vite/src/types.ts:190`. (completed)
+    - Updated `BaseRuntimeConfig.ssrManifest` to use `Manifest` type.
+50. Consolidate duplicate and overlapping types by merging `BundleInfo`/`Bundle` (`packages/fastify-vite/src/types.ts:31`, `packages/fastify-vite/src/types.ts:37`), moving `RouteType`/`Ctx`/`RendererOption` from `packages/fastify-vite/src/index.ts` into `packages/fastify-vite/src/types.ts`, and replacing inline args with `CreateRouteArgs` (`packages/fastify-vite/src/config/defaults.ts:86`, `packages/fastify-vite/src/types.ts:129`). (completed)
+    - Moved `Loosen`, `RouteType`, `Ctx`, `RendererFunctions`, `RendererOption` from `index.ts` to `types.ts`.
+    - Added `ClientRouteArgs` type for the common `{ client, route }` pattern.
+    - Updated `CreateRouteHandler` and `CreateErrorHandler` to use `ClientRouteArgs`.
+    - Made `CreateRouteArgs` extend `ClientRouteArgs`.
+    - Updated `defaults.ts` to use `ClientRouteArgs` type.
+    - Updated `FastifyViteOptions.bundle.manifest` to use `Manifest` type.
+    - Re-exported all moved types from `index.ts` for consumers.
 
 ## Phase 15: Strictness and verification
 

--- a/packages/fastify-vite/src/config/bundle.ts
+++ b/packages/fastify-vite/src/config/bundle.ts
@@ -42,7 +42,7 @@ export async function resolveSSRBundle({
       }
     }
   } else {
-    bundle.manifest = []
+    bundle.manifest = {}
   }
   return bundle
 }
@@ -72,7 +72,7 @@ export async function resolveSPABundle({
     }
     bundle.indexHtml = await readFile(indexHtmlPath, 'utf8')
   } else {
-    bundle.manifest = []
+    bundle.manifest = {}
   }
   return bundle
 }

--- a/packages/fastify-vite/src/config/defaults.ts
+++ b/packages/fastify-vite/src/config/defaults.ts
@@ -2,12 +2,12 @@ import type { FastifyInstance } from 'fastify'
 import { createHtmlTemplateFunction } from '../html.ts'
 import type {
   ClientEntries,
+  ClientRouteArgs,
   CreateRouteArgs,
   ConfigOptions,
   ErrorHandler,
   HtmlFunction,
   RenderResult,
-  RouteDefinition,
   RouteHandler,
   RuntimeConfig,
 } from '../types.ts'
@@ -84,7 +84,7 @@ export const DefaultConfig: ConfigOptions = {
   },
 
   createRouteHandler(
-    { client, route }: { client?: unknown; route?: RouteDefinition },
+    { client, route }: ClientRouteArgs,
     scope: FastifyInstance,
     config: RuntimeConfig,
   ): RouteHandler {
@@ -113,7 +113,11 @@ export const DefaultConfig: ConfigOptions = {
     }
   },
 
-  createErrorHandler(_args, _scope: FastifyInstance, config: RuntimeConfig): ErrorHandler {
+  createErrorHandler(
+    _args: ClientRouteArgs,
+    _scope: FastifyInstance,
+    config: RuntimeConfig,
+  ): ErrorHandler {
     return (error, req, reply) => {
       if (config.dev) {
         console.log(error)

--- a/packages/fastify-vite/src/index.ts
+++ b/packages/fastify-vite/src/index.ts
@@ -1,43 +1,59 @@
 import type { FastifyInstance, FastifyPluginCallback, FastifyReply, FastifyRequest } from 'fastify'
-import type { UserConfig } from 'vite'
+import type { Manifest, UserConfig } from 'vite'
 import fp from 'fastify-plugin'
 import { configure } from './config.ts'
 import type {
+  Bundle,
   ClientEntries,
   ClientModule,
+  ClientRouteArgs,
   CreateErrorHandler,
   CreateHtmlFunction,
   CreateHtmlTemplateFunction,
   CreateRoute,
+  CreateRouteArgs,
   CreateRouteHandler,
+  Ctx,
   DecoratedReply,
   DevRuntimeConfig,
   HtmlFunction,
+  Loosen,
   ProdRuntimeConfig,
   RenderContext,
+  RendererFunctions,
+  RendererOption,
   RenderFunction,
   RenderResult,
   RouteDefinition,
+  RouteType,
   RuntimeConfig,
 } from './types.ts'
 
 // Re-export types for consumers
 export type {
+  Bundle,
   ClientEntries,
   ClientModule,
+  ClientRouteArgs,
   CreateErrorHandler,
   CreateHtmlFunction,
   CreateHtmlTemplateFunction,
   CreateRoute,
+  CreateRouteArgs,
   CreateRouteHandler,
+  Ctx,
   DecoratedReply,
   DevRuntimeConfig,
   HtmlFunction,
+  Loosen,
   ProdRuntimeConfig,
   RenderContext,
+  RendererFunctions,
+  RendererOption,
   RenderFunction,
   RenderResult,
   RouteDefinition,
+  RouteType,
   RuntimeConfig,
 }
 
@@ -53,86 +69,6 @@ declare module 'fastify' {
   }
 }
 
-// Types for renderer options
-type Loosen<T> = T & Record<string, unknown>
-
-type RouteType = Partial<{
-  server: unknown
-  req: unknown
-  reply: unknown
-  head: unknown
-  state: unknown
-  data: Record<string, unknown>
-  firstRender: boolean
-  layout: unknown
-  getMeta: unknown
-  getData: unknown
-  onEnter: unknown
-  streaming: unknown
-  clientOnly: unknown
-  serverOnly: unknown
-}>
-
-type Ctx = Loosen<{
-  routes: Array<RouteType>
-  context: unknown
-  body: unknown
-  stream: unknown
-  data: unknown
-}>
-
-interface RendererFunctions {
-  createHtmlTemplateFunction(source: string): unknown
-  createHtmlFunction(
-    source: string,
-    scope?: unknown,
-    config?: unknown,
-  ): (ctx: Ctx) => Promise<unknown>
-  createRenderFunction(
-    args: Loosen<{
-      routes?: Array<RouteType>
-      create?: (arg0: Record<string, unknown>) => unknown
-      createApp: unknown
-    }>,
-  ): Promise<
-    (
-      server: unknown,
-      req: unknown,
-      reply: unknown,
-    ) =>
-      | (Ctx | { element: string; hydration?: string })
-      | Promise<Ctx | { element: string; hydration?: string }>
-  >
-}
-
-interface RendererOption<
-  CM = string | Record<string, unknown> | unknown,
-  C = unknown,
-> extends RendererFunctions {
-  clientModule: CM
-  createErrorHandler(
-    client: C,
-    scope: FastifyInstance,
-    config?: unknown,
-  ): (error: Error, req?: FastifyRequest, reply?: FastifyReply) => void
-  createRoute(
-    args: Loosen<{
-      client?: C
-      handler?: (...args: unknown[]) => unknown
-      errorHandler: (error: Error, req?: FastifyRequest, reply?: FastifyReply) => void
-      route?: RouteType
-    }>,
-    scope: FastifyInstance,
-    config: unknown,
-  ): void
-  createRouteHandler(
-    client: C,
-    scope: FastifyInstance,
-    config?: unknown,
-  ): (req: FastifyRequest, reply: FastifyReply) => Promise<unknown>
-  prepareClient(clientModule: CM, scope?: FastifyInstance, config?: unknown): Promise<C>
-}
-
 export interface FastifyViteOptions extends Partial<RendererOption> {
   dev?: boolean
   root: string
@@ -141,7 +77,7 @@ export interface FastifyViteOptions extends Partial<RendererOption> {
   vite?: UserConfig
   viteConfig?: string
   bundle?: {
-    manifest?: object
+    manifest?: Manifest
     indexHtml?: string | Buffer
     dir?: string
   }


### PR DESCRIPTION
- Replace local Vite config loader types with Vite exports (ConfigEnv, UserConfigExport)
- Change ssrBuild to isSsrBuild to align with Vite's ConfigEnv interface
- Import and use Vite's Manifest type for bundle.manifest and ssrManifest
- Merge Bundle as deprecated alias for BundleInfo
- Fix bundle.ts to use empty object {} for dev mode manifest (Manifest type)
- Move renderer types (Loosen, RouteType, Ctx, RendererFunctions, RendererOption) from index.ts to types.ts
- Add ClientRouteArgs type for common { client, route } pattern
- Update CreateRouteHandler/CreateErrorHandler to use ClientRouteArgs
- Make CreateRouteArgs extend ClientRouteArgs
- Re-export all moved types from index.ts for consumers
