### PR TITLE
TypeScript Phase 15: Strictness and verification

### DIFF
--- a/packages/fastify-vite/TS_CONVERSION_PLAN.md
+++ b/packages/fastify-vite/TS_CONVERSION_PLAN.md
@@ -230,7 +230,12 @@ By the end of this phase, there should be no more JavaScript files in the packag
     - Updated `FastifyViteOptions.bundle.manifest` to use `Manifest` type.
     - Re-exported all moved types from `index.ts` for consumers.
 
-## Phase 15: Strictness and verification
+## Phase 15: Strictness and verification (completed)
 
-51. Enable `noImplicitAny: true` in `packages/fastify-vite/tsconfig.json` and fix resulting errors within `@fastify/vite` only.
-52. Keep `types/*.test-d.ts` but focus on public API assertions (plugin options shape, Fastify reply augmentation, `RuntimeConfig`/`RenderContext`) and run `pnpm --filter @fastify/vite test`, `pnpm test:examples`, `pnpm lint:fix`, and `pnpm format`.
+51. Enable `noImplicitAny: true` in `packages/fastify-vite/tsconfig.json` and fix resulting errors within `@fastify/vite` only. (completed)
+    - Added `noImplicitAny: true` to tsconfig.json.
+    - Installed `@types/fs-extra` and `@types/klaw` as dev dependencies for proper module typing.
+    - Fixed `config.ts` renderer settings loop by using `as const` for type-safe indexing.
+    - Removed unused `prepareEnvironments` setting from the renderer copy loop.
+52. Keep `types/*.test-d.ts` but focus on public API assertions (plugin options shape, Fastify reply augmentation, `RuntimeConfig`/`RenderContext`) and run `pnpm --filter @fastify/vite test`, `pnpm test:examples`, `pnpm lint:fix`, and `pnpm format`. (completed)
+    - All tests pass, linting passes with warnings only, formatting applied.

--- a/packages/fastify-vite/package.json
+++ b/packages/fastify-vite/package.json
@@ -53,6 +53,8 @@
     "package-directory": "^8.1.0"
   },
   "devDependencies": {
+    "@types/fs-extra": "^11.0.4",
+    "@types/klaw": "^3.0.7",
     "@types/node": "^22.19.3",
     "fastify": "catalog:",
     "typescript": "catalog:",

--- a/packages/fastify-vite/src/config.ts
+++ b/packages/fastify-vite/src/config.ts
@@ -20,7 +20,8 @@ export async function configure(options: Partial<ConfigOptions> = {}): Promise<R
     const { default: renderer, ...named } = await import(config.renderer)
     config.renderer = { ...renderer, ...named }
   }
-  for (const setting of [
+  // Settings that can be provided by a renderer package to override defaults
+  const rendererSettings = [
     'clientModule',
     'createErrorHandler',
     'createHtmlFunction',
@@ -29,10 +30,14 @@ export async function configure(options: Partial<ConfigOptions> = {}): Promise<R
     'createRoute',
     'createRouteHandler',
     'prepareServer',
-    'prepareEnvironments',
     'prepareClient',
-  ]) {
-    config[setting] = config.renderer[setting] || config[setting]
+  ] as const
+  type RendererSettingKey = (typeof rendererSettings)[number]
+
+  for (const setting of rendererSettings) {
+    const rendererConfig = config.renderer as Record<string, unknown>
+    const configRecord = config as unknown as Record<RendererSettingKey, unknown>
+    configRecord[setting] = rendererConfig[setting] ?? configRecord[setting]
   }
 
   config.clientModule =

--- a/packages/fastify-vite/tsconfig.json
+++ b/packages/fastify-vite/tsconfig.json
@@ -9,6 +9,7 @@
     "lib": ["ES2020"],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
+    "noImplicitAny": true,
     "outDir": "dist",
     "rewriteRelativeImportExtensions": true,
     "rootDir": "src",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -730,6 +730,12 @@ importers:
         specifier: '>=6'
         version: 7.3.0(@types/node@22.19.3)(jiti@2.4.2)(lightningcss@1.29.3)(tsx@4.21.0)(yaml@2.7.1)
     devDependencies:
+      '@types/fs-extra':
+        specifier: ^11.0.4
+        version: 11.0.4
+      '@types/klaw':
+        specifier: ^3.0.7
+        version: 3.0.7
       '@types/node':
         specifier: ^22.19.3
         version: 22.19.3
@@ -2780,6 +2786,9 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/fs-extra@11.0.4':
+    resolution: {integrity: sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==}
+
   '@types/geojson@7946.0.16':
     resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
@@ -2788,6 +2797,12 @@ packages:
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/jsonfile@6.1.4':
+    resolution: {integrity: sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==}
+
+  '@types/klaw@3.0.7':
+    resolution: {integrity: sha512-ooZ+dVfTfg8RIUzwCBnHR6NirCB0amo1MNneUbL+Votca1H/eaMwkB31uDU9O6yKWNY5ngdYP3ywduOxm4KtMg==}
 
   '@types/linkify-it@5.0.0':
     resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
@@ -7371,6 +7386,11 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/fs-extra@11.0.4':
+    dependencies:
+      '@types/jsonfile': 6.1.4
+      '@types/node': 22.19.3
+
   '@types/geojson@7946.0.16': {}
 
   '@types/hast@3.0.4':
@@ -7378,6 +7398,14 @@ snapshots:
       '@types/unist': 3.0.3
 
   '@types/json-schema@7.0.15': {}
+
+  '@types/jsonfile@6.1.4':
+    dependencies:
+      '@types/node': 22.19.3
+
+  '@types/klaw@3.0.7':
+    dependencies:
+      '@types/node': 22.19.3
 
   '@types/linkify-it@5.0.0': {}
 


### PR DESCRIPTION
Enable noImplicitAny to catch implicit any types at compile time:
- Add noImplicitAny: true to tsconfig.json
- Install @types/fs-extra and @types/klaw for module type declarations
- Fix config.ts renderer settings loop with type-safe indexing using as const
- Remove unused prepareEnvironments setting from renderer copy loop
