### PR TITLE
New feature: baseAssetUrl for CDN assets

### DIFF
--- a/.changeset/sixty-candles-learn.md
+++ b/.changeset/sixty-candles-learn.md
@@ -1,0 +1,5 @@
+---
+"@fastify/vite": minor
+---
+
+New feature: `baseAssetUrl` to allow serving assets from a CDN

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -22,6 +22,23 @@ When set to `true`, **disables SSR** and just sets up integration for delivering
 
 This can be customized however by providing your own `createHtmlFunction()`.
 
+### `baseAssetUrl`
+
+Custom base URL for assets in production HTML output. Use this for CDN deployments where static assets are served from a different origin than your application server.
+
+```js
+await server.register(FastifyVite, {
+  root: import.meta.url,
+  baseAssetUrl: process.env.CDN_URL,
+})
+```
+
+This option works by replacing Vite's [`base`](https://vite.dev/config/shared-options.html#base) path in your HTML with the specified URL. For example, if your Vite `base` is `/` (the default), then `/assets/main.js` becomes `https://cdn.example.com/assets/main.js`. If your Vite `base` is `/app/`, then `/app/assets/main.js` becomes `https://cdn.example.com/assets/main.js`.
+
+The transformation happens once at server startup, so there's no per-request overhead. Local `@fastify/static` routes are still registered as a fallback.
+
+See [Serving assets from a CDN](/guide/build-and-deploy#serving-assets-from-a-cdn) for more details.
+
 ### `renderer`
 
 A single configuration object which can be used to set all [Renderer options](/config/#renderer-options).

--- a/packages/fastify-vite/src/config.ts
+++ b/packages/fastify-vite/src/config.ts
@@ -13,8 +13,11 @@ export async function configure(options: FastifyViteOptions): Promise<RuntimeCon
   const [vite, viteConfig] = await resolveViteConfig(root, dev, config)
   Object.assign(config, { vite, viteConfig })
 
+  const baseAssetUrl = options.baseAssetUrl
+  const originalBase = vite.base || '/'
+
   const resolveBundle = options.spa ? resolveSPABundle : resolveSSRBundle
-  const bundle = await resolveBundle({ dev, vite, root })
+  const bundle = await resolveBundle({ dev, vite, root, baseAssetUrl, originalBase })
   Object.assign(config, { bundle })
   if (typeof config.renderer === 'string') {
     const { default: renderer, ...named } = await import(config.renderer)

--- a/packages/fastify-vite/src/config/bundle.ts
+++ b/packages/fastify-vite/src/config/bundle.ts
@@ -4,12 +4,15 @@ import { readFile } from 'node:fs/promises'
 
 import { resolveIfRelative } from '../ioutils.ts'
 import { getApplicationRootDir } from './paths.ts'
+import { transformAssetUrls } from '../html-assets.ts'
 import type { Bundle, BundleConfig } from '../types/bundle.ts'
 
 export async function resolveSSRBundle({
   dev,
   vite,
   root,
+  baseAssetUrl,
+  originalBase,
 }: BundleConfig): Promise<Bundle | undefined> {
   const bundle: Bundle = {}
   let clientOutDir: string
@@ -29,7 +32,11 @@ export async function resolveSSRBundle({
     if (!existsSync(indexHtmlPath)) {
       return
     }
-    bundle.indexHtml = await readFile(indexHtmlPath, 'utf8')
+    let indexHtml = await readFile(indexHtmlPath, 'utf8')
+    if (baseAssetUrl && originalBase) {
+      indexHtml = await transformAssetUrls(indexHtml, originalBase, baseAssetUrl)
+    }
+    bundle.indexHtml = indexHtml
     const manifestPaths = [
       join(clientOutDir, 'ssr-manifest.json'),
       join(clientOutDir, '.vite/ssr-manifest.json'),
@@ -51,6 +58,8 @@ export async function resolveSPABundle({
   dev,
   vite,
   root,
+  baseAssetUrl,
+  originalBase,
 }: BundleConfig): Promise<Bundle | undefined> {
   const bundle: Bundle = {}
   if (!dev) {
@@ -70,7 +79,11 @@ export async function resolveSPABundle({
     if (!existsSync(indexHtmlPath)) {
       return
     }
-    bundle.indexHtml = await readFile(indexHtmlPath, 'utf8')
+    let indexHtml = await readFile(indexHtmlPath, 'utf8')
+    if (baseAssetUrl && originalBase) {
+      indexHtml = await transformAssetUrls(indexHtml, originalBase, baseAssetUrl)
+    }
+    bundle.indexHtml = indexHtml
   } else {
     bundle.manifest = {}
   }

--- a/packages/fastify-vite/src/html-assets.test.ts
+++ b/packages/fastify-vite/src/html-assets.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest'
+import { transformAssetUrls } from './html-assets.ts'
+
+describe('transformAssetUrls', () => {
+  it('transforms script src attributes', async () => {
+    const html = '<script type="module" src="/assets/main.js"></script>'
+    const result = await transformAssetUrls(html, '/', 'https://cdn.example.com')
+    expect(result).toBe(
+      '<script type="module" src="https://cdn.example.com/assets/main.js"></script>',
+    )
+  })
+
+  it('transforms link href attributes', async () => {
+    const html = '<link rel="stylesheet" href="/assets/style.css">'
+    const result = await transformAssetUrls(html, '/', 'https://cdn.example.com')
+    expect(result).toBe('<link rel="stylesheet" href="https://cdn.example.com/assets/style.css">')
+  })
+
+  it('transforms img src attributes', async () => {
+    const html = '<img src="/assets/image.png" alt="test">'
+    const result = await transformAssetUrls(html, '/', 'https://cdn.example.com')
+    expect(result).toBe('<img src="https://cdn.example.com/assets/image.png" alt="test">')
+  })
+
+  it('transforms multiple asset types in the same document', async () => {
+    const html = [
+      '<!DOCTYPE html>',
+      '<html>',
+      '<head>',
+      '  <link rel="stylesheet" href="/assets/style.css">',
+      '  <script type="module" src="/assets/main.js"></script>',
+      '</head>',
+      '<body>',
+      '  <img src="/assets/logo.png">',
+      '</body>',
+      '</html>',
+    ].join('\n')
+
+    const result = await transformAssetUrls(html, '/', 'https://cdn.example.com')
+
+    expect(result).toContain('href="https://cdn.example.com/assets/style.css"')
+    expect(result).toContain('src="https://cdn.example.com/assets/main.js"')
+    expect(result).toContain('src="https://cdn.example.com/assets/logo.png"')
+  })
+
+  it('handles custom Vite base paths', async () => {
+    const html = '<script type="module" src="/app/assets/main.js"></script>'
+    const result = await transformAssetUrls(html, '/app/', 'https://cdn.example.com')
+    expect(result).toBe(
+      '<script type="module" src="https://cdn.example.com/assets/main.js"></script>',
+    )
+  })
+
+  it('handles custom base path without trailing slash', async () => {
+    const html = '<script type="module" src="/app/assets/main.js"></script>'
+    const result = await transformAssetUrls(html, '/app', 'https://cdn.example.com')
+    expect(result).toBe(
+      '<script type="module" src="https://cdn.example.com/assets/main.js"></script>',
+    )
+  })
+
+  it('preserves external http URLs', async () => {
+    const html = '<script src="http://external.com/script.js"></script>'
+    const result = await transformAssetUrls(html, '/', 'https://cdn.example.com')
+    expect(result).toBe('<script src="http://external.com/script.js"></script>')
+  })
+
+  it('preserves external https URLs', async () => {
+    const html = '<script src="https://external.com/script.js"></script>'
+    const result = await transformAssetUrls(html, '/', 'https://cdn.example.com')
+    expect(result).toBe('<script src="https://external.com/script.js"></script>')
+  })
+
+  it('preserves data URLs', async () => {
+    const html = '<img src="data:image/png;base64,ABC123">'
+    const result = await transformAssetUrls(html, '/', 'https://cdn.example.com')
+    expect(result).toBe('<img src="data:image/png;base64,ABC123">')
+  })
+
+  it('transforms srcset attribute for img tags', async () => {
+    const html = '<img srcset="/assets/small.jpg 1x, /assets/large.jpg 2x">'
+    const result = await transformAssetUrls(html, '/', 'https://cdn.example.com')
+    expect(result).toBe(
+      '<img srcset="https://cdn.example.com/assets/small.jpg 1x, https://cdn.example.com/assets/large.jpg 2x">',
+    )
+  })
+
+  it('transforms srcset attribute for source tags', async () => {
+    const html = '<source srcset="/assets/image.webp" type="image/webp">'
+    const result = await transformAssetUrls(html, '/', 'https://cdn.example.com')
+    expect(result).toBe(
+      '<source srcset="https://cdn.example.com/assets/image.webp" type="image/webp">',
+    )
+  })
+
+  it('transforms video src and poster attributes', async () => {
+    const html = '<video src="/assets/video.mp4" poster="/assets/poster.jpg"></video>'
+    const result = await transformAssetUrls(html, '/', 'https://cdn.example.com')
+    expect(result).toBe(
+      '<video src="https://cdn.example.com/assets/video.mp4" poster="https://cdn.example.com/assets/poster.jpg"></video>',
+    )
+  })
+
+  it('transforms audio src attribute', async () => {
+    const html = '<audio src="/assets/audio.mp3"></audio>'
+    const result = await transformAssetUrls(html, '/', 'https://cdn.example.com')
+    expect(result).toBe('<audio src="https://cdn.example.com/assets/audio.mp3"></audio>')
+  })
+
+  it('normalizes trailing slash in CDN URL', async () => {
+    const html = '<script src="/assets/main.js"></script>'
+    const result = await transformAssetUrls(html, '/', 'https://cdn.example.com/')
+    expect(result).toBe('<script src="https://cdn.example.com/assets/main.js"></script>')
+  })
+
+  it('does not transform URLs that do not match the base path', async () => {
+    const html = '<script src="/other/script.js"></script>'
+    const result = await transformAssetUrls(html, '/app/', 'https://cdn.example.com')
+    expect(result).toBe('<script src="/other/script.js"></script>')
+  })
+
+  it('leaves URLs without base prefix unchanged when base is not /', async () => {
+    const html = '<link href="/favicon.ico" rel="icon">'
+    const result = await transformAssetUrls(html, '/app/', 'https://cdn.example.com')
+    expect(result).toBe('<link href="/favicon.ico" rel="icon">')
+  })
+})

--- a/packages/fastify-vite/src/html-assets.ts
+++ b/packages/fastify-vite/src/html-assets.ts
@@ -1,0 +1,124 @@
+import { HTMLRewriter } from 'html-rewriter-wasm'
+
+/**
+ * Transforms asset URLs in HTML content from one base path to a CDN URL.
+ *
+ * @param html - The HTML content to transform
+ * @param originalBase - The original Vite base path (e.g., '/' or '/app/')
+ * @param baseAssetUrl - The CDN base URL (e.g., 'https://cdn.example.com')
+ * @returns Transformed HTML with asset URLs pointing to the CDN
+ */
+export async function transformAssetUrls(
+  html: string,
+  originalBase: string,
+  baseAssetUrl: string,
+): Promise<string> {
+  const encoder = new TextEncoder()
+  const decoder = new TextDecoder()
+
+  let output = ''
+  const rewriter = new HTMLRewriter((chunk) => {
+    output += decoder.decode(chunk)
+  })
+
+  // Normalize paths: ensure originalBase ends with / and baseAssetUrl has no trailing /
+  const normalizedBase = originalBase.endsWith('/') ? originalBase : `${originalBase}/`
+  const normalizedCdn = baseAssetUrl.endsWith('/') ? baseAssetUrl.slice(0, -1) : baseAssetUrl
+
+  const transformUrl = (url: string | null): string | null => {
+    if (!url) return null
+
+    // Skip external URLs and data URLs
+    if (url.startsWith('http://') || url.startsWith('https://') || url.startsWith('data:')) {
+      return null
+    }
+
+    // Check if URL starts with the original base
+    if (url.startsWith(normalizedBase)) {
+      // Replace base with CDN URL
+      const path = url.slice(normalizedBase.length)
+      return `${normalizedCdn}/${path}`
+    }
+
+    // Handle URLs starting with just /
+    if (normalizedBase === '/' && url.startsWith('/') && !url.startsWith('//')) {
+      return `${normalizedCdn}${url}`
+    }
+
+    return null
+  }
+
+  const transformSrcset = (srcset: string | null): string | null => {
+    if (!srcset) return null
+
+    const entries = srcset.split(',').map((entry) => entry.trim())
+    let modified = false
+
+    const transformed = entries.map((entry) => {
+      const parts = entry.split(/\s+/)
+      if (parts.length === 0) return entry
+
+      const url = parts[0]
+      const newUrl = transformUrl(url)
+      if (newUrl) {
+        modified = true
+        parts[0] = newUrl
+      }
+      return parts.join(' ')
+    })
+
+    return modified ? transformed.join(', ') : null
+  }
+
+  // Tags with src attribute
+  const srcTags = ['script', 'img', 'source', 'video', 'audio']
+  for (const tag of srcTags) {
+    rewriter.on(tag, {
+      element(element) {
+        const src = element.getAttribute('src')
+        const newSrc = transformUrl(src)
+        if (newSrc) {
+          element.setAttribute('src', newSrc)
+        }
+
+        // Handle srcset for img and source
+        if (tag === 'img' || tag === 'source') {
+          const srcset = element.getAttribute('srcset')
+          const newSrcset = transformSrcset(srcset)
+          if (newSrcset) {
+            element.setAttribute('srcset', newSrcset)
+          }
+        }
+
+        // Handle poster for video
+        if (tag === 'video') {
+          const poster = element.getAttribute('poster')
+          const newPoster = transformUrl(poster)
+          if (newPoster) {
+            element.setAttribute('poster', newPoster)
+          }
+        }
+      },
+    })
+  }
+
+  // Link tag with href attribute
+  rewriter.on('link', {
+    element(element) {
+      const href = element.getAttribute('href')
+      const newHref = transformUrl(href)
+      if (newHref) {
+        element.setAttribute('href', newHref)
+      }
+    },
+  })
+
+  try {
+    await rewriter.write(encoder.encode(html))
+    await rewriter.end()
+  } finally {
+    rewriter.free()
+  }
+
+  return output
+}

--- a/packages/fastify-vite/src/types/bundle.ts
+++ b/packages/fastify-vite/src/types/bundle.ts
@@ -11,4 +11,6 @@ export interface BundleConfig {
   dev: boolean
   vite: ExtendedResolvedViteConfig
   root: string
+  baseAssetUrl?: string
+  originalBase?: string
 }

--- a/packages/fastify-vite/src/types/options.ts
+++ b/packages/fastify-vite/src/types/options.ts
@@ -36,6 +36,12 @@ export interface FastifyViteOptions extends Partial<RendererOption> {
    * Use this when mounting @fastify/vite under a path prefix.
    */
   prefix?: string
+  /**
+   * Custom base URL for assets in production HTML output.
+   * Use this for CDN deployments where static assets are served from a different origin.
+   * Example: `baseAssetUrl: process.env.CDN_URL`
+   */
+  baseAssetUrl?: string
 }
 
 /** Internal resolved configuration after defaults and renderer merged */


### PR DESCRIPTION
# The Story of `baseAssetUrl`: Serving Your Assets from a CDN

## What Problem Are We Solving?

Picture this: You've built a beautiful web app with Fastify and Vite. It works great on your laptop. You deploy it to a server, and it's fine... until you get popular. Suddenly your server is sweating, serving both your dynamic pages AND every single CSS file, JavaScript bundle, and image to thousands of users.

The classic solution? Put your static assets on a CDN (Content Delivery Network). CloudFront, Cloudflare, Bunny.net—these services have servers all over the world. When a user in Tokyo requests your `main.js`, they get it from a server in Tokyo, not your origin server in Virginia.

But here's the catch: Vite builds your HTML with paths like `/assets/main-abc123.js`. Your server is at `https://myapp.com`, but your CDN is at `https://cdn.myapp.com`. How do you make the HTML point to the CDN without rebuilding your entire app for each environment?

That's what `baseAssetUrl` solves. It rewrites asset URLs in your HTML **at server startup**, so you can deploy the same build to staging (no CDN) and production (with CDN) just by changing an environment variable.

## The Architecture: A One-Time Transformation

The key insight here is that we don't want to do this work on every request. HTML transformation is CPU work, and doing it per-request would defeat the purpose of using a CDN in the first place.

Instead, we transform the HTML **once**, when the server boots:

```
Server Start
    │
    ├─► Read vite.config.json (to get the original base path)
    │
    ├─► Read dist/client/index.html
    │
    ├─► If baseAssetUrl is set:
    │       └─► Transform all asset URLs in the HTML
    │
    └─► Store the (possibly transformed) HTML in memory
            │
            ├─► Every request just uses this pre-transformed HTML
            └─► No per-request CPU cost
```

This is the same pattern Vite itself uses—do expensive work upfront, serve fast at runtime.

## How the Code Flows

Let me walk you through the journey of a request:

### 1. Configuration Phase (`src/config.ts`)

When `@fastify/vite` initializes, it calls `configure()`. This is where we check for `baseAssetUrl`:

```typescript
const baseAssetUrl = options.baseAssetUrl
const originalBase = vite.base || '/' // Usually '/' unless you configured Vite differently
```

The library doesn't impose any specific environment variable name. Instead, the application author decides how to configure it:

```javascript
await server.register(fastifyVite, {
  root: import.meta.url,
  baseAssetUrl: process.env.CDN_URL, // Use whatever env var makes sense for your app
})
```

This follows the principle of minimal assumptions—the library provides the mechanism, you decide the policy.

### 2. Bundle Resolution (`src/config/bundle.ts`)

Both `resolveSSRBundle()` and `resolveSPABundle()` now accept `baseAssetUrl` and `originalBase`. After reading `index.html` from disk:

```typescript
let indexHtml = await readFile(indexHtmlPath, 'utf8')
if (baseAssetUrl && originalBase) {
  indexHtml = await transformAssetUrls(indexHtml, originalBase, baseAssetUrl)
}
bundle.indexHtml = indexHtml
```

Notice the guard: we only transform if `baseAssetUrl` is set. No config? No transformation. The feature is completely opt-in.

### 3. The Transformation Engine (`src/html-assets.ts`)

This is where the magic happens. We use `html-rewriter-wasm`, a WebAssembly port of Cloudflare's HTML rewriter. It's fast, streaming, and doesn't build a full DOM tree in memory.

Here's the mental model:

```
Original HTML                         Transformed HTML
─────────────────                     ─────────────────
<script src="/assets/main.js">   ──►  <script src="https://cdn.example.com/assets/main.js">
<link href="/assets/style.css">  ──►  <link href="https://cdn.example.com/assets/style.css">
<img src="/logo.png">            ──►  <img src="https://cdn.example.com/logo.png">
```

But we're careful about what we transform:

- **External URLs** (`https://...`, `http://...`) → Leave alone! They're already pointing somewhere specific.
- **Data URLs** (`data:image/png;base64,...`) → Leave alone! These are inline, not files.
- **URLs that don't match the base** → Leave alone! If your Vite base is `/app/` and you have `/other/thing.js`, that's not a Vite asset.

The `srcset` attribute deserves special mention. It's not just one URL—it's a comma-separated list of URLs with size hints:

```html
<img srcset="/small.jpg 1x, /large.jpg 2x" />
```

We parse each entry, transform the URL part, and reassemble. It's fiddly but necessary for responsive images.

## Why html-rewriter-wasm?

You might wonder: why not just use regex? Or a DOM parser like cheerio?

**Regex is fragile.** HTML is not a regular language. You can't reliably parse it with regex. There are always edge cases—attributes with quotes, attributes without quotes, self-closing tags, CDATA sections...

**DOM parsers are heavy.** They build a complete tree in memory, which is overkill when you just need to modify a few attributes. They also "normalize" the HTML, potentially changing whitespace or attribute order.

**html-rewriter-wasm is "just right."** It's a streaming SAX-style parser compiled to WebAssembly. It's fast, low-memory, and only touches the parts you tell it to. Cloudflare uses the original (non-WASM) version to transform HTML at the edge for millions of requests per second.

The pattern is elegant:

```typescript
const rewriter = new HTMLRewriter((chunk) => {
  output += decoder.decode(chunk)
})

rewriter.on('script', {
  element(element) {
    const src = element.getAttribute('src')
    if (shouldTransform(src)) {
      element.setAttribute('src', transform(src))
    }
  },
})

await rewriter.write(encoder.encode(html))
await rewriter.end()
rewriter.free() // Don't forget to free the WASM memory!
```

## Lessons Learned

### 1. Let Users Choose Their Configuration Strategy

Rather than imposing a specific environment variable name like `VITE_ASSETS_BASE_URL`, we let the application author decide:

```javascript
// They choose the env var name
baseAssetUrl: process.env.CDN_URL

// Or hardcode it
baseAssetUrl: 'https://cdn.example.com'

// Or use a config file
baseAssetUrl: config.cdn.baseUrl
```

This follows the principle of minimal assumptions. The library provides the mechanism (URL rewriting), the user decides the policy (how to configure it). It's more flexible and doesn't pollute the global env namespace.

### 2. Do Expensive Work Once

Per-request processing is the enemy of scalability. If you can do something at startup, do it at startup. This is why we transform the HTML once and store the result:

- Startup cost: ~10ms to transform HTML
- Per-request cost: 0ms (just serve the pre-transformed string)

Over millions of requests, that's a huge difference.

### 3. Be Conservative About What You Transform

The safest transformation is no transformation. We only change URLs that:

1. Match the original Vite base path
2. Are not already external
3. Are not data URLs

If in doubt, leave it alone. A user can always manually specify a full URL if they need something different.

### 4. Test Edge Cases Explicitly

Look at our test file. We don't just test the happy path:

```typescript
it('transforms script src attributes', ...)           // Basic case
it('handles custom Vite base paths', ...)             // /app/ instead of /
it('preserves external https URLs', ...)              // Don't break external scripts
it('preserves data URLs', ...)                        // Don't break inline images
it('transforms srcset attribute for img tags', ...)   // Multi-URL attribute
it('does not transform URLs that do not match...', ...)  // Wrong base path
```

Each test documents a decision. Future maintainers (including yourself in 6 months) will thank you.

### 5. TypeScript Types Document Intent

Adding `baseAssetUrl` to `BundleConfig` wasn't just about making the compiler happy. It documents that these values flow through the system:

```typescript
export interface BundleConfig {
  dev: boolean
  vite: ExtendedResolvedViteConfig
  root: string
  baseAssetUrl?: string // ← "This is optional, and here's where it comes from"
  originalBase?: string // ← "We need the original base to know what to replace"
}
```

Someone reading this interface instantly understands the data model.

## Potential Pitfalls

### 1. Don't Forget `rewriter.free()`

`html-rewriter-wasm` allocates WebAssembly memory. If you don't call `free()`, you'll leak memory. We use try/finally to ensure cleanup:

```typescript
try {
  await rewriter.write(encoder.encode(html))
  await rewriter.end()
} finally {
  rewriter.free()
}
```

### 2. Trailing Slashes Matter

URLs are finicky about slashes:

- `https://cdn.example.com` + `/assets/main.js` = `https://cdn.example.com/assets/main.js` ✓
- `https://cdn.example.com/` + `/assets/main.js` = `https://cdn.example.com//assets/main.js` ✗

We normalize both the CDN URL (strip trailing slash) and the base path (ensure trailing slash) to avoid double-slash bugs.

### 3. This Only Transforms HTML

If your JavaScript code constructs asset URLs dynamically (like `fetch('/assets/data.json')`), those won't be transformed. The client code still runs with the original base. For truly dynamic assets, you'd need to either:

- Use Vite's `import.meta.env.BASE_URL` in your client code
- Configure your CDN to also proxy requests from your origin

The `baseAssetUrl` feature is specifically for the static asset references that Vite embeds in the built HTML.

## The Bigger Picture

This feature is a small example of a larger pattern in web infrastructure: **separating build artifacts from deployment configuration**.

Vite builds your app with certain assumptions (base path, asset hashing, etc.). But deployment configuration—CDN URLs, API endpoints, feature flags—should be injectable at runtime. This lets you:

1. Build once, deploy many times
2. Promote the exact same artifact from staging to production
3. Roll back instantly by pointing to old artifacts

`baseAssetUrl` is one piece of this puzzle, specifically for the "where do assets live?" question. It's not glamorous, but it's the kind of infrastructure plumbing that makes real-world deployments work smoothly.

---

_Written while implementing the baseAssetUrl feature for @fastify/vite. The best code is code that solves a real problem elegantly, and then gets out of the way._
