### PR TITLE
Refactor Vite config resolution with proper TypeScript types

### DIFF
--- a/packages/fastify-vite/src/config.ts
+++ b/packages/fastify-vite/src/config.ts
@@ -1,6 +1,6 @@
 import { DefaultConfig } from './config/defaults.ts'
 import { resolveClientModule, resolveRoot } from './config/paths.ts'
-import { resolveViteConfig } from './config/vite-config.ts'
+import { resolveDevViteConfig, resolveProdViteConfig } from './config/vite-config.ts'
 import { resolveSSRBundle, resolveSPABundle } from './config/bundle.ts'
 import type { FastifyViteOptions, RuntimeConfig } from './types/options.ts'
 
@@ -10,8 +10,10 @@ export async function configure(options: FastifyViteOptions): Promise<RuntimeCon
   const dev = typeof options.dev === 'boolean' ? options.dev : defaultConfig.dev
   const config = Object.assign(defaultConfig, { ...options }) as RuntimeConfig
   config.root = root
-  const [vite, viteConfig] = await resolveViteConfig(root, dev, config)
-  Object.assign(config, { vite, viteConfig })
+  const vite = dev
+    ? await resolveDevViteConfig(root, { spa: config.spa })
+    : await resolveProdViteConfig(root, { distDir: config.distDir })
+  Object.assign(config, { vite })
 
   const baseAssetUrl = options.baseAssetUrl
   const originalBase = vite.base || '/'

--- a/packages/fastify-vite/src/config.ts
+++ b/packages/fastify-vite/src/config.ts
@@ -8,22 +8,25 @@ export async function configure(options: FastifyViteOptions): Promise<RuntimeCon
   const defaultConfig = { ...DefaultConfig }
   const root = resolveRoot(options.root)
   const dev = typeof options.dev === 'boolean' ? options.dev : defaultConfig.dev
-  const config = Object.assign(defaultConfig, { ...options }) as RuntimeConfig
-  config.root = root
-  const vite = dev
-    ? await resolveDevViteConfig(root, { spa: config.spa })
-    : await resolveProdViteConfig(root, { distDir: config.distDir })
-  Object.assign(config, { vite })
+  const runtimeConfig = Object.assign(defaultConfig, { ...options }) as RuntimeConfig
+
+  runtimeConfig.root = root
+
+  const viteConfig = dev
+    ? await resolveDevViteConfig(root, { spa: runtimeConfig.spa })
+    : await resolveProdViteConfig(root, { distDir: runtimeConfig.distDir })
+
+  Object.assign(runtimeConfig, { viteConfig })
 
   const baseAssetUrl = options.baseAssetUrl
-  const originalBase = vite.base || '/'
+  const originalBase = viteConfig.base || '/'
 
   const resolveBundle = options.spa ? resolveSPABundle : resolveSSRBundle
-  const bundle = await resolveBundle({ dev, vite, root, baseAssetUrl, originalBase })
-  Object.assign(config, { bundle })
-  if (typeof config.renderer === 'string') {
-    const { default: renderer, ...named } = await import(config.renderer)
-    config.renderer = { ...renderer, ...named }
+  const bundle = await resolveBundle({ dev, vite: viteConfig, root, baseAssetUrl, originalBase })
+  Object.assign(runtimeConfig, { bundle })
+  if (typeof runtimeConfig.renderer === 'string') {
+    const { default: renderer, ...named } = await import(runtimeConfig.renderer)
+    runtimeConfig.renderer = { ...renderer, ...named }
   }
   // Settings that can be provided by a renderer package to override defaults
   const rendererSettings = [
@@ -40,13 +43,15 @@ export async function configure(options: FastifyViteOptions): Promise<RuntimeCon
   type RendererSettingKey = (typeof rendererSettings)[number]
 
   for (const setting of rendererSettings) {
-    const rendererConfig = config.renderer as Record<string, unknown>
-    const configRecord = config as unknown as Record<RendererSettingKey, unknown>
+    const rendererConfig = runtimeConfig.renderer as Record<string, unknown>
+    const configRecord = runtimeConfig as unknown as Record<RendererSettingKey, unknown>
     configRecord[setting] = rendererConfig[setting] ?? configRecord[setting]
   }
 
-  config.clientModule =
-    vite.fastify.clientModule ?? config.clientModule ?? resolveClientModule(vite.root)
+  runtimeConfig.clientModule =
+    viteConfig.fastify.clientModule ??
+    runtimeConfig.clientModule ??
+    resolveClientModule(viteConfig.root)
 
-  return config
+  return runtimeConfig
 }

--- a/packages/fastify-vite/src/config/vite-config.ts
+++ b/packages/fastify-vite/src/config/vite-config.ts
@@ -22,12 +22,14 @@ type UserConfigModule =
       default: UserConfigExport | ExtendedUserConfig | ExtendedUserConfigFn
     }
 
-function findViteConfigJson(appRoot: string, folderNames: string[] = ['dist', 'build']) {
+const VITE_CONFIG_JSON = 'vite.config.json'
+
+export function findViteConfigJson(appRoot: string, folderNames: string[] = ['dist', 'build']) {
   for (const folderName of folderNames) {
     const folder = join(appRoot, folderName)
 
     // Check folder/vite.config.json
-    let configPath = join(folder, 'vite.config.json')
+    let configPath = join(folder, VITE_CONFIG_JSON)
     if (existsSync(configPath)) {
       return configPath
     }
@@ -37,7 +39,7 @@ function findViteConfigJson(appRoot: string, folderNames: string[] = ['dist', 'b
       for (const entry of readdirSync(folder)) {
         const entryPath = join(folder, entry)
         if (lstatSync(entryPath).isDirectory()) {
-          configPath = join(entryPath, 'vite.config.json')
+          configPath = join(entryPath, VITE_CONFIG_JSON)
           if (existsSync(configPath)) {
             return configPath
           }
@@ -48,7 +50,7 @@ function findViteConfigJson(appRoot: string, folderNames: string[] = ['dist', 'b
     }
 
     // Check client/folder/ - common pattern for projects with nested client folder
-    configPath = join(appRoot, 'client', folderName, 'vite.config.json')
+    configPath = join(appRoot, 'client', folderName, VITE_CONFIG_JSON)
     if (existsSync(configPath)) {
       return configPath
     }
@@ -82,7 +84,7 @@ export interface ResolveProdViteConfigOptions {
  *
  * @throws Error if no Vite config file is found
  */
-async function resolveDevViteConfig(
+export async function resolveDevViteConfig(
   root: string,
   { spa }: ResolveDevViteConfigOptions = {},
 ): Promise<ResolvedDevViteConfig> {
@@ -142,7 +144,7 @@ async function resolveDevViteConfig(
  *
  * @throws Error if cached config file is not found
  */
-async function resolveProdViteConfig(
+export async function resolveProdViteConfig(
   root: string,
   { distDir }: ResolveProdViteConfigOptions = {},
 ): Promise<SerializableViteConfig> {
@@ -151,7 +153,7 @@ async function resolveProdViteConfig(
   let viteConfigDistFile: string | null
   if (distDir) {
     if (isAbsolute(distDir)) {
-      viteConfigDistFile = join(dirname(distDir), 'vite.config.json')
+      viteConfigDistFile = join(dirname(distDir), VITE_CONFIG_JSON)
     } else {
       viteConfigDistFile = findViteConfigJson(appRoot, [distDir])
     }
@@ -170,5 +172,3 @@ async function resolveProdViteConfig(
 
   return JSON.parse(await readFile(viteConfigDistFile, 'utf-8'))
 }
-
-export { resolveDevViteConfig, resolveProdViteConfig }

--- a/packages/fastify-vite/src/types/bundle.ts
+++ b/packages/fastify-vite/src/types/bundle.ts
@@ -1,5 +1,5 @@
 import type { Manifest } from 'vite'
-import type { ExtendedResolvedViteConfig } from './vite-configs.ts'
+import type { ViteConfigForBundle } from './vite-configs.ts'
 
 export interface Bundle {
   manifest?: Manifest
@@ -9,7 +9,7 @@ export interface Bundle {
 
 export interface BundleConfig {
   dev: boolean
-  vite: ExtendedResolvedViteConfig
+  vite: ViteConfigForBundle
   root: string
   baseAssetUrl?: string
   originalBase?: string

--- a/packages/fastify-vite/src/types/options.ts
+++ b/packages/fastify-vite/src/types/options.ts
@@ -55,7 +55,7 @@ export interface ResolvedFastifyViteConfig {
 
   // Override types that differ from FastifyViteOptions
   bundle: Bundle
-  vite?: unknown
+  viteConfig?: ExtendedResolvedViteConfig | SerializableViteConfig
   renderer: Record<string, unknown> | string
 
   // Internal properties not in FastifyViteOptions
@@ -112,13 +112,14 @@ interface BaseRuntimeConfig extends Omit<ResolvedFastifyViteConfig, 'dev' | 'vit
 /** Runtime config in development mode with full Vite resolved config */
 export interface DevRuntimeConfig extends BaseRuntimeConfig {
   dev: true
-  vite: ExtendedResolvedViteConfig
+  viteConfig: ExtendedResolvedViteConfig
 }
 
 /** Runtime config in production mode with serialized Vite config from vite.config.json */
 export interface ProdRuntimeConfig extends BaseRuntimeConfig {
   dev: false
-  vite: ExtendedResolvedViteConfig | SerializableViteConfig
+  viteConfig: SerializableViteConfig
 }
 
+/** Resolved fastify-vite configuration built by merging options with default configs */
 export type RuntimeConfig = DevRuntimeConfig | ProdRuntimeConfig

--- a/packages/fastify-vite/src/types/options.ts
+++ b/packages/fastify-vite/src/types/options.ts
@@ -17,7 +17,6 @@ export interface FastifyViteOptions extends Partial<RendererOption> {
   spa?: boolean
   renderer?: string | Partial<RendererOption>
   vite?: UserConfig
-  viteConfig?: string
   bundle?: {
     manifest?: Manifest
     indexHtml?: string | Buffer
@@ -51,7 +50,6 @@ export interface ResolvedFastifyViteConfig {
   spa: boolean
 
   // These stay optional (filled in by configure())
-  viteConfig?: string
   distDir?: string
   prefix?: string
 

--- a/packages/fastify-vite/src/types/vite-configs.ts
+++ b/packages/fastify-vite/src/types/vite-configs.ts
@@ -1,4 +1,4 @@
-import type { ResolvedConfig as ViteResolvedConfig, UserConfig } from 'vite'
+import type { ResolvedConfig as ViteResolvedConfig, ResolvedBuildOptions, UserConfig } from 'vite'
 
 export interface ViteFastifyConfig {
   clientModule?: string
@@ -23,6 +23,28 @@ export interface SerializableViteConfig extends WithFastifyConfig {
   root?: string
   build?: {
     assetsDir?: string
+    outDir?: string
+  }
+}
+
+/**
+ * The resolved Vite config returned in dev mode.
+ * Extends ExtendedUserConfig but with build limited to assetsDir and outDir,
+ * and fastify guaranteed to be present.
+ */
+export interface ResolvedDevViteConfig extends Omit<ExtendedUserConfig, 'build' | 'fastify'> {
+  fastify: ViteFastifyConfig
+  build: Pick<ResolvedBuildOptions, 'assetsDir' | 'outDir'>
+}
+
+/**
+ * Minimal Vite config interface required by bundle resolution.
+ * This is the common interface satisfied by both SerializableViteConfig and ResolvedDevViteConfig.
+ */
+export interface ViteConfigForBundle {
+  fastify?: ViteFastifyConfig
+  root?: string
+  build?: {
     outDir?: string
   }
 }


### PR DESCRIPTION
# Summary

- Introduce proper TypeScript types for Vite configuration throughout the codebase
- Split `resolveViteConfig` into two focused functions: `resolveDevViteConfig` and `resolveProdViteConfig`
- Replace `process.exit(1)` and null returns with proper error throwing

# Changes

**Type improvements:**

- Add `SerializableViteConfig` type for the JSON config read in production
- Add `ResolvedDevViteConfig` type for the live config resolved in development
- Use discriminated union on `dev` flag for `RuntimeConfig` (`DevRuntimeConfig` | `ProdRuntimeConfig`)
- Remove unused `vite` field from options, rename to `viteConfig` for clarity

**Function split:**

- `resolveDevViteConfig(root, { spa })` → `Promise<ResolvedDevViteConfig>`
- `resolveProdViteConfig(root, { distDir })` → `Promise<SerializableViteConfig>`

Each function now has a single return type (no union, no null case) and throws descriptive errors on failure instead of calling `process.exit(1)` or returning null.

**Other cleanups:**

- Export `findViteConfigJson` for potential reuse
- Extract `VITE_CONFIG_JSON` constant
- Rename `config` to `runtimeConfig` in configure() for clarity