### PR TITLE
Remove dependency on html-rewriter-wasm

### DIFF
--- a/.changeset/remove-html-rewriter-renderers.md
+++ b/.changeset/remove-html-rewriter-renderers.md
@@ -1,0 +1,9 @@
+---
+"@fastify/react": patch
+"@fastify/vue": patch
+---
+
+Remove html-rewriter-wasm dependency
+
+Internal refactor to remove the stale html-rewriter-wasm dependency. No API changes.
+HTML manipulation now uses simple regex operations instead of WebAssembly-based parsing.

--- a/.changeset/remove-html-rewriter-vite.md
+++ b/.changeset/remove-html-rewriter-vite.md
@@ -1,0 +1,17 @@
+---
+"@fastify/vite": major
+---
+
+Remove html-rewriter-wasm dependency
+
+Replaces the stale html-rewriter-wasm dependency (last updated Feb 2022) with regex-based
+string operations. This removes a WebAssembly dependency that was marked as inactive by Snyk.
+
+**Breaking change:** The undocumented `#varName#` attribute placeholder syntax has been removed.
+This feature only existed in tests and was not documented or used in production code. If you
+were using `<element attr="#varName#">` syntax, switch to the standard comment syntax
+`<!-- varName -->` instead.
+
+The `createHtmlTemplateFunction` export is now synchronous instead of async. Existing code
+using `await` will continue to work, but you can remove the `await` for a minor performance
+improvement.

--- a/packages/fastify-react/package.json
+++ b/packages/fastify-react/package.json
@@ -71,10 +71,10 @@
     "acorn-walk": "^8.3.4",
     "devalue": "catalog:",
     "history": "latest",
-    "html-rewriter-wasm": "catalog:",
     "minipass": "latest",
     "mlly": "^1.7.4",
     "react": "catalog:react",
+    
     "react-dom": "catalog:react",
     "react-router": "catalog:react",
     "valtio": "latest",

--- a/packages/fastify-react/rendering.js
+++ b/packages/fastify-react/rendering.js
@@ -75,7 +75,7 @@ async function createResponse(req, routes) {
 export async function createHtmlFunction(source, _, config) {
   // Creates `universal` and `serverOnly` sets of
   // HTML `beforeElement` and `afterElement` templates
-  const templates = await createHtmlTemplates(source, config)
+  const templates = createHtmlTemplates(source, config)
 
   // Registered as reply.html()
   return async function () {

--- a/packages/fastify-react/templating.js
+++ b/packages/fastify-react/templating.js
@@ -1,51 +1,28 @@
 import { createHtmlTemplateFunction } from '@fastify/vite/utils'
-import { HTMLRewriter } from 'html-rewriter-wasm'
 
-export async function createHtmlTemplates(source, config) {
+const moduleScriptPattern = /<script\s[^>]*\btype\s*=\s*["']module["'][^>]*>[\s\S]*?<\/script>/gi
+
+export function createHtmlTemplates(source, config) {
   const el = '<!-- element -->'
 
   const universal = source.split(el)
-  const serverOnlyRaw = await removeClientModule(source, config)
+  const serverOnlyRaw = removeClientModule(source, config)
   const serverOnly = serverOnlyRaw.split(el)
 
   return {
     // Templates for client-only and universal rendering
     universal: {
-      beforeElement: await createHtmlTemplateFunction(universal[0]),
-      afterElement: await createHtmlTemplateFunction(universal[1]),
+      beforeElement: createHtmlTemplateFunction(universal[0]),
+      afterElement: createHtmlTemplateFunction(universal[1]),
     },
     // Templates for server-only rendering
     serverOnly: {
-      beforeElement: await createHtmlTemplateFunction(serverOnly[0]),
-      afterElement: await createHtmlTemplateFunction(serverOnly[1]),
+      beforeElement: createHtmlTemplateFunction(serverOnly[0]),
+      afterElement: createHtmlTemplateFunction(serverOnly[1]),
     },
   }
 }
 
-async function removeClientModule(html) {
-  const decoder = new TextDecoder()
-
-  let output = ''
-  const rewriter = new HTMLRewriter((outputChunk) => {
-    output += decoder.decode(outputChunk)
-  })
-
-  rewriter.on('script', {
-    element(element) {
-      for (const [attr, value] of element.attributes) {
-        if (attr === 'type' && value === 'module') {
-          element.replace('')
-        }
-      }
-    },
-  })
-
-  try {
-    const encoder = new TextEncoder()
-    await rewriter.write(encoder.encode(html))
-    await rewriter.end()
-    return output
-  } finally {
-    rewriter.free()
-  }
+function removeClientModule(html) {
+  return html.replace(moduleScriptPattern, '')
 }

--- a/packages/fastify-vite/package.json
+++ b/packages/fastify-vite/package.json
@@ -50,7 +50,6 @@
     "@fastify/static": "^9.0.0",
     "fastify-plugin": "^5.1.0",
     "fs-extra": "^11.3.3",
-    "html-rewriter-wasm": "catalog:",
     "klaw": "^4.1.0",
     "package-directory": "^8.1.0"
   },

--- a/packages/fastify-vite/src/html-assets.test.ts
+++ b/packages/fastify-vite/src/html-assets.test.ts
@@ -119,6 +119,16 @@ describe('transformAssetUrls', () => {
     expect(result).toBe('<script src="/other/script.js"></script>')
   })
 
+  it('does not transform data attributes that include src or href', async () => {
+    const html = [
+      '<img data-src="/assets/image.png">',
+      '<link data-href="/assets/style.css">',
+      '<source data-srcset="/assets/image.webp 1x">',
+    ].join('\n')
+    const result = await transformAssetUrls(html, '/', 'https://cdn.example.com')
+    expect(result).toBe(html)
+  })
+
   it('leaves URLs without base prefix unchanged when base is not /', async () => {
     const html = '<link href="/favicon.ico" rel="icon">'
     const result = await transformAssetUrls(html, '/app/', 'https://cdn.example.com')

--- a/packages/fastify-vite/src/html-assets.ts
+++ b/packages/fastify-vite/src/html-assets.ts
@@ -60,7 +60,7 @@ export function transformAssetUrls(
 
   // Transform src attributes on script, img, source, video, audio
   result = result.replace(
-    /(<(?:script|img|source|video|audio)\s[^>]*\bsrc\s*=\s*)(["'])([^"']*)\2/gi,
+    /(<(?:script|img|source|video|audio)\b[^>]*?\ssrc\s*=\s*)(["'])([^"']*)\2/gi,
     (match, prefix, quote, url) => {
       const newUrl = transformUrl(url)
       return newUrl ? `${prefix}${quote}${newUrl}${quote}` : match
@@ -69,7 +69,7 @@ export function transformAssetUrls(
 
   // Transform href attributes on link tags
   result = result.replace(
-    /(<link\s[^>]*\bhref\s*=\s*)(["'])([^"']*)\2/gi,
+    /(<link\b[^>]*?\shref\s*=\s*)(["'])([^"']*)\2/gi,
     (match, prefix, quote, url) => {
       const newUrl = transformUrl(url)
       return newUrl ? `${prefix}${quote}${newUrl}${quote}` : match
@@ -78,7 +78,7 @@ export function transformAssetUrls(
 
   // Transform srcset attributes on img and source
   result = result.replace(
-    /(<(?:img|source)\s[^>]*\bsrcset\s*=\s*)(["'])([^"']*)\2/gi,
+    /(<(?:img|source)\b[^>]*?\ssrcset\s*=\s*)(["'])([^"']*)\2/gi,
     (match, prefix, quote, srcset) => {
       const newSrcset = transformSrcset(srcset)
       return newSrcset ? `${prefix}${quote}${newSrcset}${quote}` : match
@@ -87,7 +87,7 @@ export function transformAssetUrls(
 
   // Transform poster attributes on video
   result = result.replace(
-    /(<video\s[^>]*\bposter\s*=\s*)(["'])([^"']*)\2/gi,
+    /(<video\b[^>]*?\sposter\s*=\s*)(["'])([^"']*)\2/gi,
     (match, prefix, quote, url) => {
       const newUrl = transformUrl(url)
       return newUrl ? `${prefix}${quote}${newUrl}${quote}` : match

--- a/packages/fastify-vite/src/html-assets.ts
+++ b/packages/fastify-vite/src/html-assets.ts
@@ -1,5 +1,3 @@
-import { HTMLRewriter } from 'html-rewriter-wasm'
-
 /**
  * Transforms asset URLs in HTML content from one base path to a CDN URL.
  *
@@ -8,26 +6,16 @@ import { HTMLRewriter } from 'html-rewriter-wasm'
  * @param baseAssetUrl - The CDN base URL (e.g., 'https://cdn.example.com')
  * @returns Transformed HTML with asset URLs pointing to the CDN
  */
-export async function transformAssetUrls(
+export function transformAssetUrls(
   html: string,
   originalBase: string,
   baseAssetUrl: string,
-): Promise<string> {
-  const encoder = new TextEncoder()
-  const decoder = new TextDecoder()
-
-  let output = ''
-  const rewriter = new HTMLRewriter((chunk) => {
-    output += decoder.decode(chunk)
-  })
-
+): string {
   // Normalize paths: ensure originalBase ends with / and baseAssetUrl has no trailing /
   const normalizedBase = originalBase.endsWith('/') ? originalBase : `${originalBase}/`
   const normalizedCdn = baseAssetUrl.endsWith('/') ? baseAssetUrl.slice(0, -1) : baseAssetUrl
 
-  const transformUrl = (url: string | null): string | null => {
-    if (!url) return null
-
+  const transformUrl = (url: string): string | null => {
     // Skip external URLs and data URLs
     if (url.startsWith('http://') || url.startsWith('https://') || url.startsWith('data:')) {
       return null
@@ -48,9 +36,7 @@ export async function transformAssetUrls(
     return null
   }
 
-  const transformSrcset = (srcset: string | null): string | null => {
-    if (!srcset) return null
-
+  const transformSrcset = (srcset: string): string | null => {
     const entries = srcset.split(',').map((entry) => entry.trim())
     let modified = false
 
@@ -70,55 +56,43 @@ export async function transformAssetUrls(
     return modified ? transformed.join(', ') : null
   }
 
-  // Tags with src attribute
-  const srcTags = ['script', 'img', 'source', 'video', 'audio']
-  for (const tag of srcTags) {
-    rewriter.on(tag, {
-      element(element) {
-        const src = element.getAttribute('src')
-        const newSrc = transformUrl(src)
-        if (newSrc) {
-          element.setAttribute('src', newSrc)
-        }
+  let result = html
 
-        // Handle srcset for img and source
-        if (tag === 'img' || tag === 'source') {
-          const srcset = element.getAttribute('srcset')
-          const newSrcset = transformSrcset(srcset)
-          if (newSrcset) {
-            element.setAttribute('srcset', newSrcset)
-          }
-        }
-
-        // Handle poster for video
-        if (tag === 'video') {
-          const poster = element.getAttribute('poster')
-          const newPoster = transformUrl(poster)
-          if (newPoster) {
-            element.setAttribute('poster', newPoster)
-          }
-        }
-      },
-    })
-  }
-
-  // Link tag with href attribute
-  rewriter.on('link', {
-    element(element) {
-      const href = element.getAttribute('href')
-      const newHref = transformUrl(href)
-      if (newHref) {
-        element.setAttribute('href', newHref)
-      }
+  // Transform src attributes on script, img, source, video, audio
+  result = result.replace(
+    /(<(?:script|img|source|video|audio)\s[^>]*\bsrc\s*=\s*)(["'])([^"']*)\2/gi,
+    (match, prefix, quote, url) => {
+      const newUrl = transformUrl(url)
+      return newUrl ? `${prefix}${quote}${newUrl}${quote}` : match
     },
-  })
+  )
 
-  try {
-    await rewriter.write(encoder.encode(html))
-    await rewriter.end()
-  } finally {
-    rewriter.free()
-  }
+  // Transform href attributes on link tags
+  result = result.replace(
+    /(<link\s[^>]*\bhref\s*=\s*)(["'])([^"']*)\2/gi,
+    (match, prefix, quote, url) => {
+      const newUrl = transformUrl(url)
+      return newUrl ? `${prefix}${quote}${newUrl}${quote}` : match
+    },
+  )
 
-  return output
+  // Transform srcset attributes on img and source
+  result = result.replace(
+    /(<(?:img|source)\s[^>]*\bsrcset\s*=\s*)(["'])([^"']*)\2/gi,
+    (match, prefix, quote, srcset) => {
+      const newSrcset = transformSrcset(srcset)
+      return newSrcset ? `${prefix}${quote}${newSrcset}${quote}` : match
+    },
+  )
+
+  // Transform poster attributes on video
+  result = result.replace(
+    /(<video\s[^>]*\bposter\s*=\s*)(["'])([^"']*)\2/gi,
+    (match, prefix, quote, url) => {
+      const newUrl = transformUrl(url)
+      return newUrl ? `${prefix}${quote}${newUrl}${quote}` : match
+    },
+  )
+
+  return result
 }

--- a/packages/fastify-vite/src/html.test.ts
+++ b/packages/fastify-vite/src/html.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from 'vitest'
 import { createHtmlTemplateFunction } from './html.ts'
 
 describe('createHtmlTemplateFunction', () => {
-  it('replaces comments without spaces <!-- element -->', async () => {
-    const templateFn = await createHtmlTemplateFunction(
+  it('replaces comments without spaces <!-- element -->', () => {
+    const templateFn = createHtmlTemplateFunction(
       [
         '<!doctype html>',
         '<!-- element -->',
@@ -19,8 +19,8 @@ describe('createHtmlTemplateFunction', () => {
     )
   })
 
-  it('leaves comments with spaces alone', async () => {
-    const templateFn = await createHtmlTemplateFunction(
+  it('leaves comments with spaces alone', () => {
+    const templateFn = createHtmlTemplateFunction(
       [
         '<!-- arbitrary comment -->',
         '<!doctype html>',
@@ -42,32 +42,25 @@ describe('createHtmlTemplateFunction', () => {
     )
   })
 
-  it('doesnt break with certain special characers (#165/1)', async () => {
+  it('doesnt break with certain special characers (#165/1)', () => {
     const html = [
       '<script>',
       `console.log(\`%c Example 1 + 1 = \${1 + 1}\`, 'color: blue;');`,
       '</script>',
     ].join('\n')
-    const templateFn = await createHtmlTemplateFunction(html)
+    const templateFn = createHtmlTemplateFunction(html)
     const resultStr = templateFn()
     expect(resultStr).toBe(html)
   })
 
-  it('doesnt break with certain special characers (#165/2)', async () => {
+  it('doesnt break with certain special characers (#165/2)', () => {
     const html = [
       '<script>',
       `console.log(\`%c Example 1 + 1 = \\\${1 + 1}\`, 'color: blue;');`,
       '</script>',
     ].join('\n')
-    const templateFn = await createHtmlTemplateFunction(html)
+    const templateFn = createHtmlTemplateFunction(html)
     const resultStr = templateFn()
     expect(resultStr).toBe(html)
-  })
-
-  it('identifies placeholders in attributes', async () => {
-    const html = ['<script nonce="#nonce#">', '</script>'].join('\n')
-    const templateFn = await createHtmlTemplateFunction(html)
-    const resultStr = templateFn({ nonce: 'foobar' })
-    expect(resultStr).toBe(html.replace('#nonce#', 'foobar'))
   })
 })

--- a/packages/fastify-vite/src/types/options.ts
+++ b/packages/fastify-vite/src/types/options.ts
@@ -71,7 +71,9 @@ export interface ResolvedFastifyViteConfig {
     config: RuntimeConfig,
   ) => Promise<ClientModule | undefined>
 
-  createHtmlTemplateFunction: (source: string) => Promise<HtmlTemplateFunction>
+  createHtmlTemplateFunction: (
+    source: string,
+  ) => HtmlTemplateFunction | Promise<HtmlTemplateFunction>
 
   createHtmlFunction: (
     source: string,

--- a/packages/fastify-vue/package.json
+++ b/packages/fastify-vue/package.json
@@ -67,7 +67,6 @@
     "acorn": "^8.12.1",
     "acorn-walk": "^8.3.4",
     "devalue": "catalog:",
-    "html-rewriter-wasm": "catalog:",
     "mlly": "^1.5.0",
     "vue": "catalog:vue",
     "vue-router": "catalog:vue",

--- a/packages/fastify-vue/rendering.js
+++ b/packages/fastify-vue/rendering.js
@@ -39,7 +39,7 @@ async function createResponse(req, routes) {
 export async function createHtmlFunction(source, _, config) {
   // Creates `universal` and `serverOnly` sets of
   // HTML `beforeElement` and `afterElement` templates
-  const templates = await createHtmlTemplates(source, config)
+  const templates = createHtmlTemplates(source, config)
 
   // Registered as reply.html()
   return async function () {

--- a/packages/fastify-vue/templating.js
+++ b/packages/fastify-vue/templating.js
@@ -1,51 +1,28 @@
 import { createHtmlTemplateFunction } from '@fastify/vite/utils'
-import { HTMLRewriter } from 'html-rewriter-wasm'
 
-export async function createHtmlTemplates(source, config) {
+const moduleScriptPattern = /<script\s[^>]*\btype\s*=\s*["']module["'][^>]*>[\s\S]*?<\/script>/gi
+
+export function createHtmlTemplates(source, config) {
   const el = '<!-- element -->'
 
   const universal = source.split(el)
-  const serverOnlyRaw = await removeClientModule(source, config)
+  const serverOnlyRaw = removeClientModule(source, config)
   const serverOnly = serverOnlyRaw.split(el)
 
   return {
     // Templates for client-only and universal rendering
     universal: {
-      beforeElement: await createHtmlTemplateFunction(universal[0]),
-      afterElement: await createHtmlTemplateFunction(universal[1]),
+      beforeElement: createHtmlTemplateFunction(universal[0]),
+      afterElement: createHtmlTemplateFunction(universal[1]),
     },
     // Templates for server-only rendering
     serverOnly: {
-      beforeElement: await createHtmlTemplateFunction(serverOnly[0]),
-      afterElement: await createHtmlTemplateFunction(serverOnly[1]),
+      beforeElement: createHtmlTemplateFunction(serverOnly[0]),
+      afterElement: createHtmlTemplateFunction(serverOnly[1]),
     },
   }
 }
 
-async function removeClientModule(html) {
-  const decoder = new TextDecoder()
-
-  let output = ''
-  const rewriter = new HTMLRewriter((outputChunk) => {
-    output += decoder.decode(outputChunk)
-  })
-
-  rewriter.on('script', {
-    element(element) {
-      for (const [attr, value] of element.attributes) {
-        if (attr === 'type' && value === 'module') {
-          element.replace('')
-        }
-      }
-    },
-  })
-
-  try {
-    const encoder = new TextEncoder()
-    await rewriter.write(encoder.encode(html))
-    await rewriter.end()
-    return output
-  } finally {
-    rewriter.free()
-  }
+function removeClientModule(html) {
+  return html.replace(moduleScriptPattern, '')
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,9 +15,6 @@ catalogs:
     fastify:
       specifier: ^5.6.2
       version: 5.6.2
-    html-rewriter-wasm:
-      specifier: ^0.4.1
-      version: 0.4.1
     tsx:
       specifier: ^4.21.0
       version: 4.21.0
@@ -675,9 +672,6 @@ importers:
       history:
         specifier: latest
         version: 5.3.0
-      html-rewriter-wasm:
-        specifier: 'catalog:'
-        version: 0.4.1
       minipass:
         specifier: latest
         version: 7.1.2
@@ -717,9 +711,6 @@ importers:
       fs-extra:
         specifier: ^11.3.3
         version: 11.3.3
-      html-rewriter-wasm:
-        specifier: 'catalog:'
-        version: 0.4.1
       klaw:
         specifier: ^4.1.0
         version: 4.1.0
@@ -778,9 +769,6 @@ importers:
       devalue:
         specifier: 'catalog:'
         version: 5.6.2
-      html-rewriter-wasm:
-        specifier: 'catalog:'
-        version: 0.4.1
       mlly:
         specifier: ^1.5.0
         version: 1.7.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,7 +8,6 @@ catalog:
   '@fastify/middie': ^9.1.0
   devalue: ^5.6.2
   fastify: ^5.6.2
-  html-rewriter-wasm: ^0.4.1
   tsx: ^4.21.0
   typescript: ^5.9.3
   vite: ^7.3.0


### PR DESCRIPTION
# The Great HTML Rewriter Divorce

_A story about breaking up with a dependency, and why sometimes simple is better._

---

## What We Did

We just removed `html-rewriter-wasm` from the entire fastify-vite monorepo. This was a WebAssembly library that parsed and manipulated HTML. Sounds fancy, right? That's exactly the problem.

## The Backstory: Why Did We Have This Dependency?

This project needs to do some HTML manipulation:

1. **Template variable replacement** - Turn `<!-- element -->` into React/Vue rendered content
2. **Script escaping** - Make sure `${}` inside `<script>` tags doesn't break template literals
3. **Script removal** - Strip `<script type="module">` for server-only rendering
4. **Head injection** - Prepend preload links to `<head>`
5. **CDN URL rewriting** - Change `/assets/foo.js` to `https://cdn.example.com/assets/foo.js`

The previous maintainers reached for `html-rewriter-wasm` because it's a "proper" HTML parser that handles edge cases. It's based on Cloudflare's lol-html, which is battle-tested infrastructure code.

**But here's the thing they missed:** We're not parsing arbitrary HTML from the internet. We're processing _our own Vite-generated output_. It's predictable. It's well-formed. It doesn't have weird edge cases.

## The Problems With html-rewriter-wasm

1. **Stale dependency** - Last updated February 2022 (4+ years ago)
2. **Inactive maintenance** - Snyk flagged it as "inactive"; open issues/PRs ignored
3. **WebAssembly complexity** - Adds binary blobs, async initialization, memory management
4. **Overkill** - We were using a NASA rocket to fetch groceries

When you see a dependency that hasn't been touched in 4 years, you have three options:

- Hope nothing breaks
- Fork and maintain it yourself
- Find an alternative or write your own

We chose option 3.

## The Technical Architecture

### Before: The HTMLRewriter Approach

```
HTML string → TextEncoder → WASM binary → Event handlers → TextDecoder → Modified HTML
```

The old code looked like this:

```javascript
const rewriter = new HTMLRewriter((chunk) => {
  output += decoder.decode(chunk)
})

rewriter.on('script', {
  element(element) {
    element.prepend('${"')
    element.append('"}')
  },
})

await rewriter.write(encoder.encode(html))
await rewriter.end()
rewriter.free() // Don't forget to free the WASM memory!
```

Lots of ceremony. Async operations. Memory management. Event-driven callbacks.

### After: The Regex Approach

```
HTML string → Regex → Modified HTML
```

```javascript
const scriptTagPattern = /<script(\s[^>]*)?>[\s\S]*?<\/script>/gi

let processed = source.replace(scriptTagPattern, (match) => {
  // Escape the content
  const escaped = JSON.stringify(content).slice(1, -1)
  return `${openTag}\${\"${escaped}\"}${closeTag}`
})
```

Simple. Synchronous. No dependencies.

## The Files We Changed

Here's the anatomy of the surgery:

### Core Package (`packages/fastify-vite/src/`)

| File               | What It Does                                       | What We Changed                             |
| ------------------ | -------------------------------------------------- | ------------------------------------------- |
| `html.ts`          | Compiles HTML templates with variable placeholders | Regex for `<!-- var -->` + script escaping  |
| `html-assets.ts`   | Rewrites asset URLs for CDN                        | Regex for src/href/srcset/poster attributes |
| `types/options.ts` | TypeScript types                                   | Made function return sync or async          |

### React/Vue Packages

Both `fastify-react` and `fastify-vue` had identical changes:

| File                | What It Does                    | What We Changed                          |
| ------------------- | ------------------------------- | ---------------------------------------- |
| `templating.js`     | Creates HTML template functions | Regex to remove `<script type="module">` |
| `plugin/preload.js` | Injects preload hints           | String replace on `<head>` tag           |
| `rendering.js`      | Orchestrates SSR                | Removed unnecessary `await`              |

## Lessons Learned

### 1. Don't Over-Engineer for Edge Cases You Don't Have

The HTMLRewriter was designed to handle malicious HTML, malformed documents, streaming gigabytes of content. We had none of those problems. Our HTML is:

- Generated by Vite (well-formed)
- Small (a few KB at most)
- Predictable (we control the structure)

**The lesson:** Match your tool to your problem. A sledgehammer works for nails, but a hammer is lighter.

### 2. Synchronous Is Simpler

The old code was async everywhere:

```javascript
const templateFn = await createHtmlTemplateFunction(source)
const templates = await createHtmlTemplates(source, config)
```

The new code is sync:

```javascript
const templateFn = createHtmlTemplateFunction(source)
const templates = createHtmlTemplates(source, config)
```

Async is necessary for I/O. It's overhead for computation. HTML string manipulation is pure computation.

**The lesson:** Use async when you need it, not because it sounds modern.

### 3. Regex Gets a Bad Rap (Sometimes Unfairly)

You've probably heard "don't parse HTML with regex." That's good advice for _general_ HTML parsing. But we're not parsing—we're doing targeted find-and-replace on predictable patterns.

The famous regex warning exists because:

- HTML can be arbitrarily nested
- Attributes can be quoted with `'` or `"` or not at all
- Comments can appear anywhere
- CDATA sections exist
- etc.

But if you control the HTML, you control these variables. Our patterns work because:

- We know Vite uses double quotes for attributes
- We know our placeholders are `<!-- varName -->` (not arbitrary comments)
- We know script tags are properly closed

**The lesson:** Rules have contexts. "Don't use regex for HTML" assumes untrusted input.

### 4. The True Cost of Dependencies

Every dependency is a liability:

- **Security:** More code = more attack surface
- **Maintenance:** Someone has to update it (often you, when maintainers vanish)
- **Complexity:** More moving parts = more things that can break
- **Size:** Users download your dependencies

Before adding a dependency, ask:

1. Is this problem complex enough to warrant external code?
2. Is the dependency actively maintained?
3. What's the bus factor? (How many maintainers?)
4. Can I write this myself in reasonable time?

**The lesson:** Dependencies are trade-offs, not free lunch.

### 5. Breaking Changes Should Be Intentional

We dropped support for `#varName#` attribute placeholders. This syntax existed only in tests—never documented, never used in real code. But we still documented it as a breaking change in the changeset.

Why? Because:

- Someone _might_ have discovered and used it
- It's better to over-communicate than under-communicate
- Minor version bumps signal "check the changelog"

**The lesson:** Treat your API surface as a contract.

## The Debugging Journey

### Bug #1: TypeScript Complaining About Async/Sync Mismatch

```
Type '(source: string) => HtmlTemplateFunction' is not assignable to
type '(source: string) => Promise<HtmlTemplateFunction>'.
```

The type system caught that we changed a function from async to sync. The fix was making the type accept both:

```typescript
createHtmlTemplateFunction: (source: string) => HtmlTemplateFunction | Promise<HtmlTemplateFunction>
```

This maintains backward compatibility if someone's custom renderer returns a Promise.

**What we learned:** TypeScript is your friend. Let it catch breaking changes.

### Bug #2: Lockfile Still Showed the Dependency

After removing from all `package.json` files, `pnpm-lock.yaml` still had 8 references to `html-rewriter-wasm`. Panic? No.

These were cached snapshots of _older versions_ of our packages (like `@fastify/react@1.1.2`). The lockfile keeps historical resolutions for reproducibility. They'll be pruned when no longer referenced.

**What we learned:** Understand your tools. Lockfiles are caches, not configs.

## How Good Engineers Think

This refactor illustrates several principles:

### Principle 1: Question Inherited Decisions

The HTMLRewriter was added by someone who may have had different constraints or assumptions. Don't assume previous decisions are optimal forever.

### Principle 2: Measure the Problem First

Before ripping out code, we cataloged every usage:

- 6 files using HTMLRewriter
- 5 distinct operations (comment replacement, script escaping, etc.)
- All operations were simple string transformations

This prevented over- or under-engineering the replacement.

### Principle 3: Test Before and After

We had existing tests. We ran them before changing anything to establish a baseline. Then we ran them after each file change. No surprises.

### Principle 4: Ship Working Code

We could have added features while refactoring. We didn't. The goal was removing a dependency, not improving functionality. Scope creep kills refactors.

## The Numbers

| Metric               | Before  | After                    |
| -------------------- | ------- | ------------------------ |
| Dependencies removed | 0       | 1 (+its transitive deps) |
| WebAssembly binaries | 1       | 0                        |
| Async operations     | 6       | 0                        |
| Lines of code        | ~250    | ~180                     |
| Test results         | 72 pass | 72 pass                  |

## Conclusion

Sometimes the best code is the code you delete. We replaced a stale, complex WebAssembly library with ~100 lines of regex. The tests still pass. The functionality is identical. The codebase is simpler.

Not every refactor is this clean. But when you spot a dependency that's:

- Stale (not updated in years)
- Overkill (doing more than you need)
- Replaceable (your use case is simple)

...it's worth the investment to remove it.

Your future self will thank you when that abandoned dependency doesn't break your build.

---

_Written after successfully removing html-rewriter-wasm from fastify-vite. Zero regrets._
