### PR TITLE
Types cleanup

### DIFF
--- a/packages/fastify-htmx/index.js
+++ b/packages/fastify-htmx/index.js
@@ -25,6 +25,7 @@ async function prepareClient(clientModule, scope, config) {
 
   let defaultLayout = null
   try {
+    // TODO: Switch to config.viteConfig once deprecated config.vite alias is removed.
     defaultLayout = await resolveLayoutFilePath(config.vite.root, 'default')
   } catch {
     scope.log.info('No default layout specified. Falling back to virtual layout.')

--- a/packages/fastify-react/routing.js
+++ b/packages/fastify-react/routing.js
@@ -106,6 +106,7 @@ export async function createRoute({ client, errorHandler, route }, scope, config
   } else {
     const { id } = route
     const htmlPath = id.replace('pages/', 'html/').replace(/\.(j|t)sx$/, '.html')
+    // TODO: Switch to config.viteConfig once deprecated config.vite alias is removed.
     let distDir = config.vite.build.outDir
     if (!isAbsolute(config.vite.build.outDir)) {
       distDir = join(config.vite.root, distDir)

--- a/packages/fastify-vite/src/config/vite-config.ts
+++ b/packages/fastify-vite/src/config/vite-config.ts
@@ -1,8 +1,9 @@
 import { existsSync, lstatSync, readdirSync } from 'node:fs'
 import { readFile } from 'node:fs/promises'
 import { dirname, isAbsolute, join } from 'node:path'
+import type { ResolvedConfig } from 'vite'
 import { getApplicationRootDir } from './paths.ts'
-import type { ExtendedResolvedViteConfig, SerializableViteConfig } from '../types/vite-configs.ts'
+import type { SerializableViteConfig } from '../types/vite-configs.ts'
 
 const VITE_CONFIG_JSON = 'vite.config.json'
 
@@ -66,7 +67,7 @@ export interface ResolveProdViteConfigOptions {
  *
  * @throws Error if no Vite config file is found
  */
-export async function resolveDevViteConfig(root: string): Promise<ExtendedResolvedViteConfig> {
+export async function resolveDevViteConfig(root: string): Promise<ResolvedConfig> {
   const configFile = findConfigFile(root)
   if (!configFile) {
     throw new Error(`No Vite config file found. Searched for vite.config.{js,mjs,ts} in: ${root}`)

--- a/packages/fastify-vite/src/mode/development.ts
+++ b/packages/fastify-vite/src/mode/development.ts
@@ -6,7 +6,6 @@ import { createServer, createServerModuleRunner } from 'vite'
 import middie, { type Handler as MiddieHandler } from '@fastify/middie'
 import type { ClientModule } from '../types/client.ts'
 import type { DevRuntimeConfig } from '../types/options.ts'
-import type { DecoratedReply } from '../types/reply.ts'
 import type { RouteDefinition } from '../types/route.ts'
 import { hasIterableRoutes, type FastifyViteDecorationPriorToSetup } from './support.ts'
 
@@ -200,15 +199,14 @@ export async function setup(
         indexHtml,
       )
 
-      const decoratedReply = reply as DecoratedReply
-      decoratedReply.html = await runtimeConfig.createHtmlFunction(
+      reply.html = await runtimeConfig.createHtmlFunction(
         transformedHtml,
         fastifyViteDecoration.scope,
         runtimeConfig,
       )
 
       if (runtimeConfig.hasRenderFunction) {
-        decoratedReply.render = await runtimeConfig.createRenderFunction(
+        reply.render = await runtimeConfig.createRenderFunction(
           hotScope[hot].client,
           fastifyViteDecoration.scope,
           runtimeConfig,

--- a/packages/fastify-vite/src/plugin.ts
+++ b/packages/fastify-vite/src/plugin.ts
@@ -2,11 +2,7 @@ import { dirname, isAbsolute, join, relative, sep } from 'node:path'
 import { writeFile } from 'node:fs/promises'
 import getDeepMergeFunction from '@fastify/deepmerge'
 import type { Plugin, ResolvedConfig, UserConfig } from 'vite'
-import type {
-  ExtendedResolvedViteConfig,
-  SerializableViteConfig,
-  ViteFastifyConfig,
-} from './types/vite-configs.ts'
+import type { SerializableViteConfig, ViteFastifyConfig } from './types/vite-configs.ts'
 
 export interface ViteFastifyPluginOptions {
   /**
@@ -28,7 +24,7 @@ export function viteFastify(options: ViteFastifyPluginOptions = {}): Plugin {
   let customOutDir: string | undefined
   let jsonFilePath: string
   let configToWrite: SerializableViteConfig
-  let resolvedConfig: ExtendedResolvedViteConfig
+  let resolvedConfig: ResolvedConfig
 
   return {
     name: 'vite-fastify',
@@ -71,7 +67,7 @@ export function viteFastify(options: ViteFastifyPluginOptions = {}): Plugin {
       const { base, build, mode, root: resolvedViteRoot } = config
       const { assetsDir } = build
 
-      resolvedConfig = config as ExtendedResolvedViteConfig
+      resolvedConfig = config
 
       resolvedConfig.fastify = { clientModule }
 

--- a/packages/fastify-vite/src/types/options.ts
+++ b/packages/fastify-vite/src/types/options.ts
@@ -105,18 +105,24 @@ interface BaseRuntimeConfig {
 export interface IncompleteRuntimeConfig extends Partial<BaseRuntimeConfig> {
   dev?: boolean
   viteConfig?: ResolvedConfig | SerializableViteConfig
+  /** @deprecated Use `viteConfig` instead. */
+  readonly vite?: ResolvedConfig | SerializableViteConfig
 }
 
 /** Runtime config in development mode with full Vite resolved config */
 export interface DevRuntimeConfig extends BaseRuntimeConfig {
   dev: true
   viteConfig: ResolvedConfig
+  /** @deprecated Use `viteConfig` instead. */
+  readonly vite: ResolvedConfig
 }
 
 /** Runtime config in production mode with serialized Vite config from vite.config.json */
 export interface ProdRuntimeConfig extends BaseRuntimeConfig {
   dev: false
   viteConfig: SerializableViteConfig
+  /** @deprecated Use `viteConfig` instead. */
+  readonly vite: SerializableViteConfig
 }
 
 /** Resolved fastify-vite configuration built by merging options with default configs */

--- a/packages/fastify-vite/src/types/options.ts
+++ b/packages/fastify-vite/src/types/options.ts
@@ -1,11 +1,12 @@
 import type { FastifyInstance, RouteHandlerMethod, RouteOptions } from 'fastify'
+import type { ResolvedConfig } from 'vite'
 
 import type { ClientEntries, ClientModule } from './client.ts'
 import type { HtmlTemplateFunction } from './html.ts'
 import type { RendererOption } from './renderer.ts'
 import type { ReplyDotHtmlFunction, ReplyDotRenderFunction } from './reply.ts'
 import type { ClientRouteArgs, CreateRouteArgs } from './route.ts'
-import type { ExtendedResolvedViteConfig, SerializableViteConfig } from './vite-configs.ts'
+import type { SerializableViteConfig } from './vite-configs.ts'
 
 /** User-provided options for the @fastify/vite plugin */
 export interface FastifyViteOptions extends Partial<RendererOption> {
@@ -103,13 +104,13 @@ interface BaseRuntimeConfig {
  */
 export interface IncompleteRuntimeConfig extends Partial<BaseRuntimeConfig> {
   dev?: boolean
-  viteConfig?: ExtendedResolvedViteConfig | SerializableViteConfig
+  viteConfig?: ResolvedConfig | SerializableViteConfig
 }
 
 /** Runtime config in development mode with full Vite resolved config */
 export interface DevRuntimeConfig extends BaseRuntimeConfig {
   dev: true
-  viteConfig: ExtendedResolvedViteConfig
+  viteConfig: ResolvedConfig
 }
 
 /** Runtime config in production mode with serialized Vite config from vite.config.json */

--- a/packages/fastify-vite/src/types/reply.ts
+++ b/packages/fastify-vite/src/types/reply.ts
@@ -23,12 +23,3 @@ export type ReplyDotHtmlFunction = (
   this: FastifyReply,
   ctx?: ReplyDotRenderResult,
 ) => FastifyReply | Promise<FastifyReply>
-
-/**
- * A FastifyReply that has been decorated with html() and render() methods.
- * This is the reply type available after vite.ready() has been called.
- */
-export interface DecoratedReply extends FastifyReply {
-  render: (ctx?: ReplyDotRenderContext) => ReplyDotRenderResult | Promise<ReplyDotRenderResult>
-  html: (ctx?: ReplyDotRenderResult) => FastifyReply | Promise<FastifyReply>
-}

--- a/packages/fastify-vite/src/types/route.ts
+++ b/packages/fastify-vite/src/types/route.ts
@@ -2,7 +2,7 @@ import type { FastifyInstance, RouteHandlerMethod, RouteOptions } from 'fastify'
 
 export interface RouteDefinition {
   path?: string
-  method?: string
+  method?: RouteOptions['method']
   configure?: (scope: FastifyInstance) => void | Promise<void>
   default?: (...args: unknown[]) => unknown
   [key: string]: unknown

--- a/packages/fastify-vite/src/types/route.ts
+++ b/packages/fastify-vite/src/types/route.ts
@@ -1,4 +1,4 @@
-import type { FastifyInstance, RouteHandlerMethod, RouteOptions } from 'fastify'
+import type { FastifyInstance, RouteOptions } from 'fastify'
 
 export interface RouteDefinition {
   path?: string
@@ -15,7 +15,5 @@ export interface ClientRouteArgs {
 }
 
 /** Full args for createRoute including handler and error handler */
-export interface CreateRouteArgs extends ClientRouteArgs {
-  handler?: RouteHandlerMethod
-  errorHandler: NonNullable<RouteOptions['errorHandler']>
-}
+export interface CreateRouteArgs
+  extends ClientRouteArgs, Pick<RouteOptions, 'handler' | 'errorHandler'> {}

--- a/packages/fastify-vite/src/types/route.ts
+++ b/packages/fastify-vite/src/types/route.ts
@@ -1,8 +1,8 @@
 import type { FastifyInstance, RouteOptions } from 'fastify'
 
-export interface RouteDefinition {
+// TODO: Revisit whether omitting `url`/`handler` is strictly needed or if we can simplify route merge/runtime behavior.
+export interface RouteDefinition extends Partial<Omit<RouteOptions, 'url' | 'handler'>> {
   path?: string
-  method?: RouteOptions['method']
   configure?: (scope: FastifyInstance) => void | Promise<void>
   default?: (...args: unknown[]) => unknown
   [key: string]: unknown

--- a/packages/fastify-vite/src/types/route.ts
+++ b/packages/fastify-vite/src/types/route.ts
@@ -1,10 +1,13 @@
 import type { FastifyInstance, RouteOptions } from 'fastify'
 
-// TODO: Revisit whether omitting `url`/`handler` is strictly needed or if we can simplify route merge/runtime behavior.
-export interface RouteDefinition extends Partial<Omit<RouteOptions, 'url' | 'handler'>> {
-  path?: string
+export interface RouteDefinition extends Partial<RouteOptions> {
   configure?: (scope: FastifyInstance) => void | Promise<void>
   default?: (...args: unknown[]) => unknown
+  // Runtime composes/injects the handler (`createRouteHandler`, plus HMR wrappers in dev).
+  handler?: never
+  path?: string
+  // Runtime sets Fastify's `url` during registration (derived from `path`).
+  url?: never
   [key: string]: unknown
 }
 

--- a/packages/fastify-vite/src/types/vite-configs.ts
+++ b/packages/fastify-vite/src/types/vite-configs.ts
@@ -16,9 +16,8 @@ declare module 'vite' {
 }
 
 /** The JSON structure written to vite.config.json by the plugin */
-export interface SerializableViteConfig extends Partial<
-  Pick<ViteResolvedConfig, 'base' | 'fastify'>
-> {
+export interface SerializableViteConfig
+  extends Pick<ViteResolvedConfig, 'root'>, Partial<Pick<ViteResolvedConfig, 'base'>> {
   build: Pick<ViteBuildOptions, 'assetsDir' | 'outDir'>
-  root: string // not read-only to allow incremental construction
+  fastify?: ViteFastifyConfig
 }

--- a/packages/fastify-vite/src/types/vite-configs.ts
+++ b/packages/fastify-vite/src/types/vite-configs.ts
@@ -9,14 +9,15 @@ export interface ViteFastifyConfig {
   outDirs?: Record<string, string>
 }
 
-/** Vite ResolvedConfig extended with fastify properties */
-export interface ExtendedResolvedViteConfig extends ViteResolvedConfig {
-  fastify?: ViteFastifyConfig
+declare module 'vite' {
+  interface ResolvedConfig {
+    fastify?: ViteFastifyConfig
+  }
 }
 
 /** The JSON structure written to vite.config.json by the plugin */
 export interface SerializableViteConfig extends Partial<
-  Pick<ExtendedResolvedViteConfig, 'base' | 'fastify'>
+  Pick<ViteResolvedConfig, 'base' | 'fastify'>
 > {
   build: Pick<ViteBuildOptions, 'assetsDir' | 'outDir'>
   root: string // not read-only to allow incremental construction

--- a/packages/fastify-vue/routing.js
+++ b/packages/fastify-vue/routing.js
@@ -112,6 +112,7 @@ export async function createRoute({ client, errorHandler, route }, scope, config
   } else {
     const { id } = route
     const htmlPath = id.replace('pages/', 'html/').replace(/\.vue$/, '.html')
+    // TODO: Switch to config.viteConfig once deprecated config.vite alias is removed.
     let distDir = config.vite.build.outDir
     if (!isAbsolute(config.vite.build.outDir)) {
       distDir = join(config.vite.root, distDir)


### PR DESCRIPTION
Clean up types by maximizing use of fastify and vite built in types

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
