### PR TITLE
Vue Vite 8 compatibility fixes

### DIFF
--- a/.changeset/fresh-drinks-change.md
+++ b/.changeset/fresh-drinks-change.md
@@ -1,0 +1,5 @@
+---
+'@fastify/vue': patch
+---
+
+Vite 8 compatibility fixes

--- a/packages/fastify-vue/plugin/virtual.js
+++ b/packages/fastify-vue/plugin/virtual.js
@@ -48,7 +48,7 @@ export async function resolveId(id) {
       if (override) {
         return override
       }
-      return id
+      return `/$app/${virtual}`
     }
   }
 }
@@ -58,7 +58,10 @@ export function loadVirtualModule(virtualInput, options) {
   if (!virtual.endsWith('.vue') && !virtual.match(/\.(ts|js)$/)) {
     virtual += options.ts ? '.ts' : '.js'
   }
-  if (!virtualModules.includes(virtual) && !virtualModulesTS.includes(virtual)) {
+  if (
+    !virtualModules.includes(virtual) &&
+    !virtualModulesTS.includes(virtual)
+  ) {
     return
   }
   let virtualRootDir = options.ts ? virtualRootTS : virtualRoot
@@ -95,7 +98,10 @@ virtualModules.includes = function (virtual) {
 
 function loadVirtualModuleOverride(viteProjectRoot, virtualInput) {
   let virtual = virtualInput
-  if (!virtualModules.includes(virtual) && !virtualModulesTS.includes(virtual)) {
+  if (
+    !virtualModules.includes(virtual) &&
+    !virtualModulesTS.includes(virtual)
+  ) {
     return
   }
   let overridePath = resolve(viteProjectRoot, virtual)

--- a/packages/fastify-vue/plugin/virtual.js
+++ b/packages/fastify-vue/plugin/virtual.js
@@ -58,10 +58,7 @@ export function loadVirtualModule(virtualInput, options) {
   if (!virtual.endsWith('.vue') && !virtual.match(/\.(ts|js)$/)) {
     virtual += options.ts ? '.ts' : '.js'
   }
-  if (
-    !virtualModules.includes(virtual) &&
-    !virtualModulesTS.includes(virtual)
-  ) {
+  if (!virtualModules.includes(virtual) && !virtualModulesTS.includes(virtual)) {
     return
   }
   let virtualRootDir = options.ts ? virtualRootTS : virtualRoot
@@ -98,10 +95,7 @@ virtualModules.includes = function (virtual) {
 
 function loadVirtualModuleOverride(viteProjectRoot, virtualInput) {
   let virtual = virtualInput
-  if (
-    !virtualModules.includes(virtual) &&
-    !virtualModulesTS.includes(virtual)
-  ) {
+  if (!virtualModules.includes(virtual) && !virtualModulesTS.includes(virtual)) {
     return
   }
   let overridePath = resolve(viteProjectRoot, virtual)

--- a/packages/fastify-vue/routing.js
+++ b/packages/fastify-vue/routing.js
@@ -35,11 +35,7 @@ export function createErrorHandler(_, scope, config) {
   }
 }
 
-export async function createRoute(
-  { client, errorHandler, route },
-  scope,
-  config,
-) {
+export async function createRoute({ client, errorHandler, route }, scope, config) {
   if (route.configure) {
     await route.configure(scope)
   }
@@ -51,13 +47,7 @@ export async function createRoute(
   RouteContext.extend(client.context)
 
   const onRequest = async (req, reply) => {
-    req.route = await RouteContext.create(
-      scope,
-      req,
-      reply,
-      route,
-      client.context,
-    )
+    req.route = await RouteContext.create(scope, req, reply, route, client.context)
   }
 
   const preHandler = [
@@ -144,10 +134,7 @@ export async function createRoute(
 
   if (route.getData) {
     // If getData is provided, register JSON endpoint for it
-    const dataPath = (route.dataPath ?? route.path).replace(
-      /:\w[\w-]*\+.*/,
-      '*',
-    )
+    const dataPath = (route.dataPath ?? route.path).replace(/:\w[\w-]*\+.*/, '*')
     scope.get(`/-/data${dataPath}`, {
       onRequest,
       async handler(req, reply) {

--- a/packages/fastify-vue/routing.js
+++ b/packages/fastify-vue/routing.js
@@ -1,5 +1,5 @@
 import { readFileSync } from 'node:fs'
-import { join, isAbsolute } from 'node:path'
+import { join } from 'node:path'
 import Youch from 'youch'
 import RouteContext from './context.js'
 import { createHtmlFunction } from './rendering.js'
@@ -35,7 +35,11 @@ export function createErrorHandler(_, scope, config) {
   }
 }
 
-export async function createRoute({ client, errorHandler, route }, scope, config) {
+export async function createRoute(
+  { client, errorHandler, route },
+  scope,
+  config,
+) {
   if (route.configure) {
     await route.configure(scope)
   }
@@ -47,7 +51,13 @@ export async function createRoute({ client, errorHandler, route }, scope, config
   RouteContext.extend(client.context)
 
   const onRequest = async (req, reply) => {
-    req.route = await RouteContext.create(scope, req, reply, route, client.context)
+    req.route = await RouteContext.create(
+      scope,
+      req,
+      reply,
+      route,
+      client.context,
+    )
   }
 
   const preHandler = [
@@ -112,11 +122,7 @@ export async function createRoute({ client, errorHandler, route }, scope, config
   } else {
     const { id } = route
     const htmlPath = id.replace('pages/', 'html/').replace(/\.vue$/, '.html')
-    // TODO: Switch to config.viteConfig once deprecated config.vite alias is removed.
-    let distDir = config.vite.build.outDir
-    if (!isAbsolute(config.vite.build.outDir)) {
-      distDir = join(config.vite.root, distDir)
-    }
+    let distDir = config.viteConfig.build.outDir
     const htmlSource = readFileSync(join(distDir, htmlPath), 'utf8')
     const htmlFunction = await createHtmlFunction(htmlSource, scope, config)
     handler = (_, reply) => htmlFunction.call(reply)
@@ -138,7 +144,10 @@ export async function createRoute({ client, errorHandler, route }, scope, config
 
   if (route.getData) {
     // If getData is provided, register JSON endpoint for it
-    const dataPath = (route.dataPath ?? route.path).replace(/:\w[\w-]*\+.*/, '*')
+    const dataPath = (route.dataPath ?? route.path).replace(
+      /:\w[\w-]*\+.*/,
+      '*',
+    )
     scope.get(`/-/data${dataPath}`, {
       onRequest,
       async handler(req, reply) {

--- a/packages/fastify-vue/virtual-ts/layout.vue
+++ b/packages/fastify-vue/virtual-ts/layout.vue
@@ -1,28 +1,31 @@
-<template>
-  <!-- eslint-disable-next-line vue/multi-word-component-names -->
-  <component :is="layout">
-    <slot />
-  </component>
-</template>
-
 <script>
-import { inject } from 'vue'
+import { h, inject, unref } from 'vue'
 import { routeLayout } from '@fastify/vue/client'
+import * as DefaultLayout from '/$app/layouts/default.vue'
 
-import * as DefaultLayout from '$app/layouts/default.vue'
-const appLayouts = import.meta.glob('/layouts/*.vue', { eager: true })
-
+const appLayouts = import.meta.glob('/layouts/*.vue', {
+  eager: true,
+})
 appLayouts['/layouts/default.vue'] ??= DefaultLayout
 
+const layouts = Object.fromEntries(
+  Object.keys(appLayouts).map((path) => [
+    path.slice(9, -4),
+    appLayouts[path].default,
+  ]),
+)
+
 export default {
-  components: Object.fromEntries(
-    Object.keys(appLayouts).map((path) => {
-      const name = path.slice(9, -4)
-      return [name, appLayouts[path].default]
-    }),
-  ),
-  setup: () => ({
-    layout: inject(routeLayout),
-  }),
+  setup(_, { slots }) {
+    const layoutRef = inject(routeLayout)
+    return () => {
+      const name = unref(layoutRef) ?? 'default'
+      const LayoutComponent = layouts[name] ?? layouts.default
+      const children = () => slots.default?.()
+      return LayoutComponent
+        ? h(LayoutComponent, null, { default: children })
+        : children()
+    }
+  },
 }
 </script>

--- a/packages/fastify-vue/virtual-ts/layout.vue
+++ b/packages/fastify-vue/virtual-ts/layout.vue
@@ -9,10 +9,7 @@ const appLayouts = import.meta.glob('/layouts/*.vue', {
 appLayouts['/layouts/default.vue'] ??= DefaultLayout
 
 const layouts = Object.fromEntries(
-  Object.keys(appLayouts).map((path) => [
-    path.slice(9, -4),
-    appLayouts[path].default,
-  ]),
+  Object.keys(appLayouts).map((path) => [path.slice(9, -4), appLayouts[path].default]),
 )
 
 export default {
@@ -22,9 +19,7 @@ export default {
       const name = unref(layoutRef) ?? 'default'
       const LayoutComponent = layouts[name] ?? layouts.default
       const children = () => slots.default?.()
-      return LayoutComponent
-        ? h(LayoutComponent, null, { default: children })
-        : children()
+      return LayoutComponent ? h(LayoutComponent, null, { default: children }) : children()
     }
   },
 }

--- a/packages/fastify-vue/virtual-ts/router.vue
+++ b/packages/fastify-vue/virtual-ts/router.vue
@@ -1,18 +1,24 @@
-<script setup>
-import Layout from '$app/layout.vue'
-</script>
+<script>
+import { h, Suspense } from 'vue'
+import { RouterView, useRoute } from 'vue-router'
+import Layout from '/$app/layout.vue'
 
-<template>
-  <RouterView v-slot="{ Component }">
-    <template v-if="$isServer">
-      <Layout>
-        <component :is="Component" :key="$route.path" />
-      </Layout>
-    </template>
-    <Suspense v-else>
-      <Layout>
-        <component :is="Component" :key="$route.path" />
-      </Layout>
-    </Suspense>
-  </RouterView>
-</template>
+export default {
+  setup() {
+    const route = useRoute()
+    const isServer = import.meta.env.SSR
+
+    return () =>
+      h(RouterView, null, {
+        default: (slotProps) => {
+          const Component = slotProps?.Component
+          const child = Component ? h(Component, { key: route.path }) : null
+          const wrapped = h(Layout, null, { default: () => child })
+          return isServer
+            ? wrapped
+            : h(Suspense, null, { default: () => wrapped })
+        },
+      })
+  },
+}
+</script>

--- a/packages/fastify-vue/virtual-ts/router.vue
+++ b/packages/fastify-vue/virtual-ts/router.vue
@@ -14,9 +14,7 @@ export default {
           const Component = slotProps?.Component
           const child = Component ? h(Component, { key: route.path }) : null
           const wrapped = h(Layout, null, { default: () => child })
-          return isServer
-            ? wrapped
-            : h(Suspense, null, { default: () => wrapped })
+          return isServer ? wrapped : h(Suspense, null, { default: () => wrapped })
         },
       })
   },

--- a/packages/fastify-vue/virtual/layout.vue
+++ b/packages/fastify-vue/virtual/layout.vue
@@ -7,10 +7,7 @@ const appLayouts = import.meta.glob('/layouts/*.vue', { eager: true })
 appLayouts['/layouts/default.vue'] ??= DefaultLayout
 
 const layouts = Object.fromEntries(
-  Object.keys(appLayouts).map((path) => [
-    path.slice(9, -4),
-    appLayouts[path].default,
-  ]),
+  Object.keys(appLayouts).map((path) => [path.slice(9, -4), appLayouts[path].default]),
 )
 
 export default {
@@ -20,9 +17,7 @@ export default {
       const name = unref(layoutRef) ?? 'default'
       const LayoutComponent = layouts[name] ?? layouts.default
       const children = () => slots.default?.()
-      return LayoutComponent
-        ? h(LayoutComponent, null, { default: children })
-        : children()
+      return LayoutComponent ? h(LayoutComponent, null, { default: children }) : children()
     }
   },
 }

--- a/packages/fastify-vue/virtual/layout.vue
+++ b/packages/fastify-vue/virtual/layout.vue
@@ -1,28 +1,29 @@
-<template>
-  <!-- eslint-disable-next-line vue/multi-word-component-names -->
-  <component :is="layout">
-    <slot />
-  </component>
-</template>
-
 <script>
-import { inject } from 'vue'
+import { h, inject, unref } from 'vue'
 import { routeLayout } from '@fastify/vue/client'
+import * as DefaultLayout from '/$app/layouts/default.vue'
 
-import * as DefaultLayout from '$app/layouts/default.vue'
 const appLayouts = import.meta.glob('/layouts/*.vue', { eager: true })
-
 appLayouts['/layouts/default.vue'] ??= DefaultLayout
 
+const layouts = Object.fromEntries(
+  Object.keys(appLayouts).map((path) => [
+    path.slice(9, -4),
+    appLayouts[path].default,
+  ]),
+)
+
 export default {
-  components: Object.fromEntries(
-    Object.keys(appLayouts).map((path) => {
-      const name = path.slice(9, -4)
-      return [name, appLayouts[path].default]
-    }),
-  ),
-  setup: () => ({
-    layout: inject(routeLayout),
-  }),
+  setup(_, { slots }) {
+    const layoutRef = inject(routeLayout)
+    return () => {
+      const name = unref(layoutRef) ?? 'default'
+      const LayoutComponent = layouts[name] ?? layouts.default
+      const children = () => slots.default?.()
+      return LayoutComponent
+        ? h(LayoutComponent, null, { default: children })
+        : children()
+    }
+  },
 }
 </script>

--- a/packages/fastify-vue/virtual/router.vue
+++ b/packages/fastify-vue/virtual/router.vue
@@ -1,18 +1,24 @@
-<script setup>
-import Layout from '$app/layout.vue'
-</script>
+<script>
+import { h, Suspense } from 'vue'
+import { RouterView, useRoute } from 'vue-router'
+import Layout from '/$app/layout.vue'
 
-<template>
-  <RouterView v-slot="{ Component }">
-    <template v-if="$isServer">
-      <Layout>
-        <component :is="Component" :key="$route.path" />
-      </Layout>
-    </template>
-    <Suspense v-else>
-      <Layout>
-        <component :is="Component" :key="$route.path" />
-      </Layout>
-    </Suspense>
-  </RouterView>
-</template>
+export default {
+  setup() {
+    const route = useRoute()
+    const isServer = import.meta.env.SSR
+
+    return () =>
+      h(RouterView, null, {
+        default: (slotProps) => {
+          const Component = slotProps?.Component
+          const child = Component ? h(Component, { key: route.path }) : null
+          const wrapped = h(Layout, null, { default: () => child })
+          return isServer
+            ? wrapped
+            : h(Suspense, null, { default: () => wrapped })
+        },
+      })
+  },
+}
+</script>

--- a/packages/fastify-vue/virtual/router.vue
+++ b/packages/fastify-vue/virtual/router.vue
@@ -14,9 +14,7 @@ export default {
           const Component = slotProps?.Component
           const child = Component ? h(Component, { key: route.path }) : null
           const wrapped = h(Layout, null, { default: () => child })
-          return isServer
-            ? wrapped
-            : h(Suspense, null, { default: () => wrapped })
+          return isServer ? wrapped : h(Suspense, null, { default: () => wrapped })
         },
       })
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -995,11 +995,11 @@ importers:
         specifier: ^2.0.2
         version: 2.0.2
       '@fastify/vite':
-        specifier: ^8.4.1
-        version: 8.4.1(fastify@5.8.4)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.4.2)(tsx@4.21.0)(yaml@2.7.1))
+        specifier: ^9.0.0
+        version: 9.0.0(fastify@5.8.4)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.4.2)(tsx@4.21.0)(yaml@2.7.1))
       '@fastify/vue':
         specifier: ^1.2.0
-        version: 1.2.0(@types/node@24.12.2)(fastify@5.8.4)(jiti@2.4.2)(lightningcss@1.32.0)(tsx@4.21.0)(typescript@6.0.2)(yaml@2.7.1)
+        version: 1.2.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.2)(fastify@5.8.4)(jiti@2.4.2)(tsx@4.21.0)(typescript@6.0.2)(yaml@2.7.1)
       '@unhead/vue':
         specifier: ^2.0.5
         version: 2.0.8(vue@3.5.26(typescript@6.0.2))
@@ -1044,11 +1044,11 @@ importers:
         specifier: ^2.0.2
         version: 2.0.2
       '@fastify/vite':
-        specifier: ^8.4.1
-        version: 8.4.1(fastify@5.8.4)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.4.2)(tsx@4.21.0)(yaml@2.7.1))
+        specifier: ^9.0.0
+        version: 9.0.0(fastify@5.8.4)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.4.2)(tsx@4.21.0)(yaml@2.7.1))
       '@fastify/vue':
         specifier: ^1.2.0
-        version: 1.2.0(@types/node@24.12.2)(fastify@5.8.4)(jiti@2.4.2)(lightningcss@1.32.0)(tsx@4.21.0)(typescript@6.0.2)(yaml@2.7.1)
+        version: 1.2.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.2)(fastify@5.8.4)(jiti@2.4.2)(tsx@4.21.0)(typescript@6.0.2)(yaml@2.7.1)
       '@unhead/vue':
         specifier: ^2.0.5
         version: 2.0.8(vue@3.5.26(typescript@6.0.2))
@@ -1090,11 +1090,11 @@ importers:
         specifier: ^2.0.2
         version: 2.0.2
       '@fastify/vite':
-        specifier: ^8.4.1
-        version: 8.4.1(fastify@5.8.4)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.14.0)(esbuild@0.27.2)(jiti@2.4.2)(tsx@4.20.3)(yaml@2.7.1))
+        specifier: ^9.0.0
+        version: 9.0.0(fastify@5.8.4)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.14.0)(esbuild@0.27.2)(jiti@2.4.2)(tsx@4.20.3)(yaml@2.7.1))
       '@fastify/vue':
         specifier: ^1.2.0
-        version: 1.2.0(@types/node@22.14.0)(fastify@5.8.4)(jiti@2.4.2)(lightningcss@1.32.0)(tsx@4.20.3)(typescript@5.9.3)(yaml@2.7.1)
+        version: 1.2.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.14.0)(esbuild@0.27.2)(fastify@5.8.4)(jiti@2.4.2)(tsx@4.20.3)(typescript@5.9.3)(yaml@2.7.1)
       '@unhead/vue':
         specifier: ^2.0.5
         version: 2.0.8(vue@3.5.26(typescript@5.9.3))
@@ -2196,8 +2196,14 @@ packages:
       fastify: '>=5'
       vite: '>=6'
 
-  '@fastify/vue@1.2.0':
-    resolution: {integrity: sha512-IzhhakCWwTssUVjmVxbkUWwVROmEWs8ROHxblwMlE1FhHAlVyPAP1QiSUKbBOqFIg/GO+2qZh0PdId4GIRbdsg==}
+  '@fastify/vite@9.0.0':
+    resolution: {integrity: sha512-KyGhrOxPK2TFQtAkgZEJcOVlKQFnK7l9QV9vz243ABgxkOkGdfu2HlYres3TuPBNBXJlG72dr2ao3VpttQFMaA==}
+    peerDependencies:
+      fastify: '>=5'
+      vite: '>=6'
+
+  '@fastify/vue@1.2.1':
+    resolution: {integrity: sha512-CeVE2OgydiUZiWNbpr5HUAx4yQmJVYUb7F8LCfilfC8gYLIfkCX6Ltvi5EfZ8CdqusD0eqlGSYnNmWvdRtqT/Q==}
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -5816,46 +5822,6 @@ packages:
       terser:
         optional: true
 
-  vite@7.3.1:
-    resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^20.19.0 || >=22.12.0
-      jiti: '>=1.21.0'
-      less: ^4.0.0
-      lightningcss: ^1.21.0
-      sass: ^1.70.0
-      sass-embedded: ^1.70.0
-      stylus: '>=0.54.8'
-      sugarss: ^5.0.0
-      terser: ^5.16.0
-      tsx: ^4.8.1
-      yaml: ^2.4.2
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      jiti:
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-      tsx:
-        optional: true
-      yaml:
-        optional: true
-
   vite@8.0.5:
     resolution: {integrity: sha512-nmu43Qvq9UopTRfMx2jOYW5l16pb3iDC1JH6yMuPkpVbzK0k+L7dfsEDH4jRgYFmsg0sTAqkojoZgzLMlwHsCQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -7134,32 +7100,6 @@ snapshots:
       fastq: 1.20.1
       glob: 13.0.6
 
-  '@fastify/vite@8.4.1(fastify@5.8.4)(vite@7.3.1(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.32.0)(tsx@4.20.3)(yaml@2.7.1))':
-    dependencies:
-      '@fastify/deepmerge': 3.2.1
-      '@fastify/middie': 9.3.1
-      '@fastify/static': 9.0.0
-      fastify: 5.8.4
-      fastify-plugin: 5.1.0
-      fs-extra: 11.3.4
-      html-rewriter-wasm: 0.4.1
-      klaw: 4.1.0
-      package-directory: 8.2.0
-      vite: 7.3.1(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.32.0)(tsx@4.20.3)(yaml@2.7.1)
-
-  '@fastify/vite@8.4.1(fastify@5.8.4)(vite@7.3.1(@types/node@24.12.2)(jiti@2.4.2)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.7.1))':
-    dependencies:
-      '@fastify/deepmerge': 3.2.1
-      '@fastify/middie': 9.3.1
-      '@fastify/static': 9.0.0
-      fastify: 5.8.4
-      fastify-plugin: 5.1.0
-      fs-extra: 11.3.4
-      html-rewriter-wasm: 0.4.1
-      klaw: 4.1.0
-      package-directory: 8.2.0
-      vite: 7.3.1(@types/node@24.12.2)(jiti@2.4.2)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.7.1)
-
   '@fastify/vite@8.4.1(fastify@5.8.4)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.14.0)(esbuild@0.27.2)(jiti@2.4.2)(tsx@4.20.3)(yaml@2.7.1))':
     dependencies:
       '@fastify/deepmerge': 3.2.1
@@ -7186,26 +7126,52 @@ snapshots:
       package-directory: 8.2.0
       vite: 8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.4.2)(tsx@4.21.0)(yaml@2.7.1)
 
-  '@fastify/vue@1.2.0(@types/node@22.14.0)(fastify@5.8.4)(jiti@2.4.2)(lightningcss@1.32.0)(tsx@4.20.3)(typescript@5.9.3)(yaml@2.7.1)':
+  '@fastify/vite@9.0.0(fastify@5.8.4)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.14.0)(esbuild@0.27.2)(jiti@2.4.2)(tsx@4.20.3)(yaml@2.7.1))':
     dependencies:
-      '@fastify/vite': 8.4.1(fastify@5.8.4)(vite@7.3.1(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.32.0)(tsx@4.20.3)(yaml@2.7.1))
+      '@fastify/deepmerge': 3.2.1
+      '@fastify/middie': 9.3.1
+      '@fastify/static': 9.0.0
+      fastify: 5.8.4
+      fastify-plugin: 5.1.0
+      fs-extra: 11.3.4
+      klaw: 4.1.0
+      package-directory: 8.2.0
+      vite: 8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.14.0)(esbuild@0.27.2)(jiti@2.4.2)(tsx@4.20.3)(yaml@2.7.1)
+
+  '@fastify/vite@9.0.0(fastify@5.8.4)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.4.2)(tsx@4.21.0)(yaml@2.7.1))':
+    dependencies:
+      '@fastify/deepmerge': 3.2.1
+      '@fastify/middie': 9.3.1
+      '@fastify/static': 9.0.0
+      fastify: 5.8.4
+      fastify-plugin: 5.1.0
+      fs-extra: 11.3.4
+      klaw: 4.1.0
+      package-directory: 8.2.0
+      vite: 8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.4.2)(tsx@4.21.0)(yaml@2.7.1)
+
+  '@fastify/vue@1.2.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.14.0)(esbuild@0.27.2)(fastify@5.8.4)(jiti@2.4.2)(tsx@4.20.3)(typescript@5.9.3)(yaml@2.7.1)':
+    dependencies:
+      '@fastify/vite': 9.0.0(fastify@5.8.4)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.14.0)(esbuild@0.27.2)(jiti@2.4.2)(tsx@4.20.3)(yaml@2.7.1))
       '@unhead/vue': 2.0.8(vue@3.5.26(typescript@5.9.3))
       acorn: 8.15.0
       acorn-walk: 8.3.4
       devalue: 5.6.2
-      html-rewriter-wasm: 0.4.1
       mlly: 1.8.0
       vue: 3.5.26(typescript@5.9.3)
       vue-router: 4.6.4(vue@3.5.26(typescript@5.9.3))
       youch: 3.3.4
     optionalDependencies:
-      vite: 7.3.1(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.32.0)(tsx@4.20.3)(yaml@2.7.1)
+      vite: 8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.14.0)(esbuild@0.27.2)(jiti@2.4.2)(tsx@4.20.3)(yaml@2.7.1)
     transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
       - '@types/node'
+      - '@vitejs/devtools'
+      - esbuild
       - fastify
       - jiti
       - less
-      - lightningcss
       - sass
       - sass-embedded
       - stylus
@@ -7215,26 +7181,28 @@ snapshots:
       - typescript
       - yaml
 
-  '@fastify/vue@1.2.0(@types/node@24.12.2)(fastify@5.8.4)(jiti@2.4.2)(lightningcss@1.32.0)(tsx@4.21.0)(typescript@6.0.2)(yaml@2.7.1)':
+  '@fastify/vue@1.2.1(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.2)(fastify@5.8.4)(jiti@2.4.2)(tsx@4.21.0)(typescript@6.0.2)(yaml@2.7.1)':
     dependencies:
-      '@fastify/vite': 8.4.1(fastify@5.8.4)(vite@7.3.1(@types/node@24.12.2)(jiti@2.4.2)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.7.1))
+      '@fastify/vite': 9.0.0(fastify@5.8.4)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.4.2)(tsx@4.21.0)(yaml@2.7.1))
       '@unhead/vue': 2.0.8(vue@3.5.26(typescript@6.0.2))
       acorn: 8.15.0
       acorn-walk: 8.3.4
       devalue: 5.6.2
-      html-rewriter-wasm: 0.4.1
       mlly: 1.8.0
       vue: 3.5.26(typescript@6.0.2)
       vue-router: 4.6.4(vue@3.5.26(typescript@6.0.2))
       youch: 3.3.4
     optionalDependencies:
-      vite: 7.3.1(@types/node@24.12.2)(jiti@2.4.2)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.7.1)
+      vite: 8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.2)(jiti@2.4.2)(tsx@4.21.0)(yaml@2.7.1)
     transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
       - '@types/node'
+      - '@vitejs/devtools'
+      - esbuild
       - fastify
       - jiti
       - less
-      - lightningcss
       - sass
       - sass-embedded
       - stylus
@@ -10596,6 +10564,7 @@ snapshots:
       '@rollup/rollup-win32-x64-gnu': 4.57.1
       '@rollup/rollup-win32-x64-msvc': 4.57.1
       fsevents: 2.3.3
+    optional: true
 
   roughjs@4.6.6:
     dependencies:
@@ -10935,38 +10904,6 @@ snapshots:
       '@types/node': 24.12.2
       fsevents: 2.3.3
       lightningcss: 1.32.0
-
-  vite@7.3.1(@types/node@22.14.0)(jiti@2.4.2)(lightningcss@1.32.0)(tsx@4.20.3)(yaml@2.7.1):
-    dependencies:
-      esbuild: 0.27.2
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-      postcss: 8.5.8
-      rollup: 4.57.1
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 22.14.0
-      fsevents: 2.3.3
-      jiti: 2.4.2
-      lightningcss: 1.32.0
-      tsx: 4.20.3
-      yaml: 2.7.1
-
-  vite@7.3.1(@types/node@24.12.2)(jiti@2.4.2)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.7.1):
-    dependencies:
-      esbuild: 0.27.2
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-      postcss: 8.5.8
-      rollup: 4.57.1
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 24.12.2
-      fsevents: 2.3.3
-      jiti: 2.4.2
-      lightningcss: 1.32.0
-      tsx: 4.21.0
-      yaml: 2.7.1
 
   vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@22.14.0)(esbuild@0.27.2)(jiti@2.4.2)(tsx@4.20.3)(yaml@2.7.1):
     dependencies:

--- a/starters/vue-base/package.json
+++ b/starters/vue-base/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@fastify/one-line-logger": "^2.0.2",
-    "@fastify/vite": "^8.4.1",
+    "@fastify/vite": "^9.0.0",
     "@fastify/vue": "^1.2.0",
     "@unhead/vue": "^2.0.5",
     "fastify": "^5.8.4",

--- a/starters/vue-kitchensink/package.json
+++ b/starters/vue-kitchensink/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@fastify/formbody": "^8.0.2",
     "@fastify/one-line-logger": "^2.0.2",
-    "@fastify/vite": "^8.4.1",
+    "@fastify/vite": "^9.0.0",
     "@fastify/vue": "^1.2.0",
     "@unhead/vue": "^2.0.5",
     "fastify": "^5.8.4",

--- a/starters/vue-typescript/package.json
+++ b/starters/vue-typescript/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@fastify/formbody": "^8.0.2",
     "@fastify/one-line-logger": "^2.0.2",
-    "@fastify/vite": "^8.4.1",
+    "@fastify/vite": "^9.0.0",
     "@fastify/vue": "^1.2.0",
     "@unhead/vue": "^2.0.5",
     "fastify": "^5.8.4",


### PR DESCRIPTION
The relative imports broke vue projects with `[plugin:vite:import-analysis] Failed to resolve import "../client/pages/client-only.vue" from "$app/routes.js". Does the file exist?`.
This updates the virtual file resolver to always return `/$app`. Also updates vue files to not use SFC to avoid vite vue plugin mismatch issues.

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
