### PR TITLE
Align RendererOption with BaseRuntimeConfig and export shared types

### DIFF
--- a/.changeset/gentle-otters-march.md
+++ b/.changeset/gentle-otters-march.md
@@ -1,0 +1,5 @@
+---
+"@fastify/vite": minor
+---
+
+Align the renderer typings with the actual runtime contract and export the shared renderer types so TypeScript renderer packages can build against them instead of redeclaring them. Also widens `reply.html()` to allow string and stream returns and a synchronous `createHtmlFunction`. Type-only.

--- a/packages/fastify-vite/src/index.test-d.ts
+++ b/packages/fastify-vite/src/index.test-d.ts
@@ -7,31 +7,31 @@ import FastifyVite, { fastifyVite, type FastifyViteOptions } from '../src/index.
 const options = {
   root: process.cwd(),
   spa: false,
-  async prepareClient({ routes: routesPromise, context: contextPromise, ...others }) {
-    const context = await contextPromise
-    const resolvedRoutes = await routesPromise
-    return { context, routes: resolvedRoutes, ...others }
+  async prepareClient(entries) {
+    return entries.ssr ?? null
   },
-  createHtmlFunction(source) {
-    return ({ routes, context, body }) => Promise.resolve()
+  async createHtmlFunction(source) {
+    return function () {
+      return this
+    }
   },
-  createRenderFunction({ create, routes, createApp }) {
-    return Promise.resolve((req) => {
+  async createRenderFunction(client) {
+    return function () {
       return { element: '', hydration: '' }
-    })
+    }
   },
   renderer: {
-    createErrorHandler(client, scope, config) {
+    createErrorHandler(args, scope, config) {
       return (error: Error, req: any, reply: any) => {}
     },
-    createRoute({ client }, scope, config) {},
-    createRouteHandler(client, scope, config) {
+    createRoute(args, scope, config) {},
+    createRouteHandler(args, scope, config) {
       return (req, res) => {
         return Promise.resolve()
       }
     },
-    prepareClient(clientModule, scope, config) {
-      return Promise.resolve(clientModule)
+    prepareClient(entries, scope, config) {
+      return Promise.resolve(entries.ssr ?? null)
     },
   },
 } satisfies FastifyViteOptions

--- a/packages/fastify-vite/src/index.ts
+++ b/packages/fastify-vite/src/index.ts
@@ -1,3 +1,4 @@
+import type { Readable } from 'node:stream'
 import type {
   FastifyError,
   FastifyInstance,
@@ -11,29 +12,49 @@ import fp from 'fastify-plugin'
 import { configure } from './config.ts'
 import { hasIterableRoutes, type FastifyViteDecorationPriorToSetup } from './mode/support.ts'
 import type { ClientEntries, ClientModule } from './types/client.ts'
+import type { HtmlTemplateFunction } from './types/html.ts'
 import type {
   DevRuntimeConfig,
   FastifyViteOptions,
   ProdRuntimeConfig,
   RuntimeConfig,
 } from './types/options.ts'
-import type { ReplyDotRenderContext, ReplyDotRenderResult } from './types/reply.ts'
-import type { RouteDefinition } from './types/route.ts'
+import type { RendererOption } from './types/renderer.ts'
+import type {
+  ReplyDotHtmlFunction,
+  ReplyDotRenderContext,
+  ReplyDotRenderFunction,
+  ReplyDotRenderResult,
+} from './types/reply.ts'
+import type { ClientRouteArgs, CreateRouteArgs, RouteDefinition } from './types/route.ts'
+import type { SerializableViteConfig } from './types/vite-configs.ts'
 
 // Re-export types for consumers
 export type {
+  ClientEntries,
+  ClientModule,
+  ClientRouteArgs,
+  CreateRouteArgs,
   DevRuntimeConfig,
   FastifyViteOptions,
+  HtmlTemplateFunction,
   ProdRuntimeConfig,
+  RendererOption,
+  ReplyDotHtmlFunction as HtmlFunction,
   ReplyDotRenderContext as RenderContext,
+  ReplyDotRenderFunction as RenderFunction,
+  ReplyDotRenderResult as RenderResult,
   RouteDefinition,
   RuntimeConfig,
+  SerializableViteConfig,
 }
 
 // Module augmentation for Fastify
 declare module 'fastify' {
   interface FastifyReply {
-    html(ctx?: ReplyDotRenderResult): FastifyReply | Promise<FastifyReply>
+    html(
+      ctx?: ReplyDotRenderResult,
+    ): FastifyReply | string | Readable | Promise<FastifyReply | string | Readable>
     render(ctx?: ReplyDotRenderContext): ReplyDotRenderResult | Promise<ReplyDotRenderResult>
   }
 

--- a/packages/fastify-vite/src/types/client.ts
+++ b/packages/fastify-vite/src/types/client.ts
@@ -1,11 +1,14 @@
+import type { RouteDefinition } from './route.ts'
+
 export interface ClientModule {
-  createApp?: (...args: unknown[]) => unknown
-  create?: (...args: unknown[]) => unknown
-  routes?: unknown
+  create?: (...args: never[]) => unknown
+  routes?:
+    | Iterable<RouteDefinition>
+    | (() => Iterable<RouteDefinition> | Promise<Iterable<RouteDefinition>>)
   [key: string]: unknown
 }
 
 export interface ClientEntries {
   ssr?: ClientModule
-  [key: string]: unknown
+  [env: string]: ClientModule | undefined
 }

--- a/packages/fastify-vite/src/types/options.ts
+++ b/packages/fastify-vite/src/types/options.ts
@@ -80,7 +80,7 @@ interface BaseRuntimeConfig {
     source: string,
     scope: FastifyInstance,
     config: RuntimeConfig,
-  ) => Promise<ReplyDotHtmlFunction>
+  ) => ReplyDotHtmlFunction | Promise<ReplyDotHtmlFunction>
 
   createRoute: (
     args: CreateRouteArgs,

--- a/packages/fastify-vite/src/types/renderer.ts
+++ b/packages/fastify-vite/src/types/renderer.ts
@@ -1,85 +1,48 @@
 import type { FastifyInstance, RouteHandlerMethod, RouteOptions } from 'fastify'
-
-/** Helper type to loosen strict object types by adding index signature */
-export type Loosen<T> = T & Record<string, unknown>
-
-/** Route properties available in renderer context */
-export type RouteType = Partial<{
-  server: unknown
-  req: unknown
-  reply: unknown
-  head: unknown
-  state: unknown
-  data: Record<string, unknown>
-  firstRender: boolean
-  layout: unknown
-  getMeta: unknown
-  getData: unknown
-  onEnter: unknown
-  streaming: unknown
-  clientOnly: unknown
-  serverOnly: unknown
-}>
-
-/** Renderer context passed to html/render functions */
-export type Ctx = Loosen<{
-  routes: Array<RouteType>
-  context: unknown
-  body: unknown
-  stream: unknown
-  data: unknown
-}>
-
-/** Renderer function definitions */
-export interface RendererFunctions {
-  createHtmlTemplateFunction(source: string): unknown
-  createHtmlFunction(
-    source: string,
-    scope?: unknown,
-    config?: unknown,
-  ): (ctx: Ctx) => Promise<unknown>
-  createRenderFunction(
-    args: Loosen<{
-      routes?: Array<RouteType>
-      create?: (arg0: Record<string, unknown>) => unknown
-      createApp: unknown
-    }>,
-  ): Promise<
-    (
-      server: unknown,
-      req: unknown,
-      reply: unknown,
-    ) =>
-      | (Ctx | { element: string; hydration?: string })
-      | Promise<Ctx | { element: string; hydration?: string }>
-  >
-}
+import type { ClientEntries, ClientModule } from './client.ts'
+import type { RuntimeConfig } from './options.ts'
+import type { ReplyDotHtmlFunction, ReplyDotRenderFunction } from './reply.ts'
+import type { ClientRouteArgs, CreateRouteArgs } from './route.ts'
 
 /** Renderer option interface for custom renderers */
-export interface RendererOption<
-  CM = string | Record<string, unknown> | unknown,
-  C = unknown,
-> extends RendererFunctions {
-  clientModule: CM
+export interface RendererOption {
+  clientModule: string
+
+  createHtmlTemplateFunction(source: string): unknown
+
+  createHtmlFunction(
+    source: string,
+    scope: FastifyInstance,
+    config: RuntimeConfig,
+  ): ReplyDotHtmlFunction | Promise<ReplyDotHtmlFunction>
+
+  createRenderFunction(
+    client: ClientModule,
+    scope: FastifyInstance,
+    config: RuntimeConfig,
+  ): Promise<ReplyDotRenderFunction>
+
   createErrorHandler(
-    client: C,
+    args: ClientRouteArgs,
     scope: FastifyInstance,
-    config?: unknown,
+    config: RuntimeConfig,
   ): NonNullable<RouteOptions['errorHandler']> | Promise<NonNullable<RouteOptions['errorHandler']>>
+
   createRoute(
-    args: Loosen<{
-      client?: C
-      handler?: RouteHandlerMethod
-      errorHandler: NonNullable<RouteOptions['errorHandler']>
-      route?: RouteType
-    }>,
+    args: CreateRouteArgs,
     scope: FastifyInstance,
-    config: unknown,
+    config: RuntimeConfig,
   ): void | Promise<void>
+
   createRouteHandler(
-    client: C,
+    args: ClientRouteArgs,
     scope: FastifyInstance,
-    config?: unknown,
+    config: RuntimeConfig,
   ): RouteHandlerMethod | Promise<RouteHandlerMethod>
-  prepareClient(clientModule: CM, scope?: FastifyInstance, config?: unknown): Promise<C>
+
+  prepareClient(
+    entries: ClientEntries,
+    scope: FastifyInstance,
+    config: RuntimeConfig,
+  ): Promise<ClientModule | null>
 }

--- a/packages/fastify-vite/src/types/reply.ts
+++ b/packages/fastify-vite/src/types/reply.ts
@@ -1,3 +1,4 @@
+import type { Readable } from 'node:stream'
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify'
 
 import type { RouteDefinition } from './route.ts'
@@ -22,4 +23,4 @@ export type ReplyDotRenderFunction = (
 export type ReplyDotHtmlFunction = (
   this: FastifyReply,
   ctx?: ReplyDotRenderResult,
-) => FastifyReply | Promise<FastifyReply>
+) => FastifyReply | string | Readable | Promise<FastifyReply | string | Readable>


### PR DESCRIPTION
Hello,

Over the past couple months I've been slowly picking at a TanStack renderer. While doing this, I noticed that the typings were rather loose, and lots of internal types were never exported to be used by the renderers. This PR tightens and exports the types so that they can be consumed by the renderer packages without requiring them to be inlined. This would likely be valuable as renderers are being migrated to TS, and to support future TS renderers.

Changes include:

- Reworked `RendererOption` so the method signatures actually match what the runtime hands them: real `scope`/`config` types, the args object that `createRoute`/`createRouteHandler`/`createErrorHandler` receive, and `prepareClient` taking the entries object and returning the resolved client. The old `Loosen`/`Ctx`/`RouteType` placeholders that stood in for all this are gone.
- Exported the types a renderer actually needs (`RendererOption`, the `reply.html`/`reply.render` function and result types, `HtmlTemplateFunction`, `SerializableViteConfig`, and the client/route arg types) so renderers can import them instead of keeping their own copies.
- Tidied up `ClientModule`: dropped the unused `createApp`, gave `routes` a real type, and loosened `create` so a renderer can narrow it to its own factory.
- Widened `reply.html()` to allow returning a string or stream (and a synchronous `createHtmlFunction`), since not every renderer hands back the reply object.

It's all type-only, no runtime changes, and nothing that was already exported got removed.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test && npm run benchmark --if-present`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
