### PR TITLE
Fix Vite 8 dev-mode resolution for React renderer virtual modules that use root-absolute `import.meta.glob()` patterns

### DIFF
--- a/.changeset/fuzzy-spiders-end.md
+++ b/.changeset/fuzzy-spiders-end.md
@@ -1,0 +1,5 @@
+---
+"@fastify/react": patch
+---
+
+Fix React renderer virtual module resolution under Vite 8 and skip preload generation when Vite closes a dev server without a production bundle.

--- a/e2e/react-base/client/index.html
+++ b/e2e/react-base/client/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <title>React base e2e</title>
+  </head>
+  <body>
+    <div id="root"><!-- element --></div>
+    <script type="module" src="$app/mount.js"></script>
+  </body>
+</html>

--- a/e2e/react-base/client/layouts/default.jsx
+++ b/e2e/react-base/client/layouts/default.jsx
@@ -1,0 +1,3 @@
+export default function DefaultLayout({ children }) {
+  return <main>{children}</main>
+}

--- a/e2e/react-base/client/pages/index.jsx
+++ b/e2e/react-base/client/pages/index.jsx
@@ -1,0 +1,9 @@
+export function getMeta() {
+  return {
+    title: 'React base e2e',
+  }
+}
+
+export default function Index() {
+  return <p>React base e2e</p>
+}

--- a/e2e/react-base/package.json
+++ b/e2e/react-base/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@fastify-vite/e2e-react-base",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "node server.js --dev",
+    "start": "NODE_ENV=production node server.js",
+    "build": "vite build --app",
+    "test": "node --test"
+  },
+  "dependencies": {
+    "@fastify/react": "workspace:^",
+    "@fastify/vite": "workspace:^",
+    "@unhead/react": "^2.1.13",
+    "fastify": "catalog:",
+    "history": "latest",
+    "minipass": "latest",
+    "react": "catalog:react",
+    "react-dom": "catalog:react",
+    "react-router": "catalog:react",
+    "valtio": "latest"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "catalog:react",
+    "vite": "catalog:"
+  }
+}

--- a/e2e/react-base/server.js
+++ b/e2e/react-base/server.js
@@ -1,0 +1,22 @@
+import Fastify from 'fastify'
+import FastifyVite from '@fastify/vite'
+import * as renderer from '@fastify/react'
+
+export async function main(dev) {
+  const server = Fastify()
+
+  await server.register(FastifyVite, {
+    root: import.meta.dirname,
+    dev: dev ?? process.argv.includes('--dev'),
+    renderer,
+  })
+
+  await server.vite.ready()
+
+  return server
+}
+
+if (process.argv[1] === import.meta.filename) {
+  const server = await main()
+  await server.listen({ port: 3000 })
+}

--- a/e2e/react-base/server.test.js
+++ b/e2e/react-base/server.test.js
@@ -1,0 +1,25 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { main } from './server.js'
+
+const getClientTransform = async (server, id) => {
+  const result = await server.vite.devServer.environments.client.transformRequest(id)
+  assert.ok(result?.code, `${id} transformed code exists`)
+  return result.code
+}
+
+test('react-base resolves virtual module glob imports in development', async (t) => {
+  const server = await main(true)
+  t.after(() => server.close())
+
+  const response = await server.inject({ method: 'GET', url: '/' })
+  assert.equal(response.statusCode, 200)
+
+  const layoutsCode = await getClientTransform(server, '$app/layouts.js')
+  assert.match(layoutsCode, /import\("\/layouts\/default\.jsx"\)/)
+  assert.doesNotMatch(layoutsCode, /\.\.\/client\/layouts\/default\.jsx/)
+
+  const routesCode = await getClientTransform(server, '$app/routes.js')
+  assert.match(routesCode, /import\("\/pages\/index\.jsx"\)/)
+  assert.doesNotMatch(routesCode, /\.\.\/client\/pages\/index\.jsx/)
+})

--- a/e2e/react-base/vite.config.js
+++ b/e2e/react-base/vite.config.js
@@ -1,0 +1,12 @@
+import { resolve } from 'node:path'
+
+import viteReact from '@vitejs/plugin-react'
+import viteFastifyReact from '@fastify/react/plugin'
+
+export default {
+  root: resolve(import.meta.dirname, 'client'),
+  plugins: [viteReact(), viteFastifyReact()],
+  ssr: {
+    external: ['use-sync-external-store'],
+  },
+}

--- a/packages/fastify-react/package.json
+++ b/packages/fastify-react/package.json
@@ -62,7 +62,9 @@
   "publishConfig": {
     "access": "public"
   },
-  "scripts": {},
+  "scripts": {
+    "test": "node --test plugin/*.test.js"
+  },
   "dependencies": {
     "@fastify/vite": "workspace:^",
     "@unhead/react": "^2.1.13",

--- a/packages/fastify-react/plugin/parsers.test.js
+++ b/packages/fastify-react/plugin/parsers.test.js
@@ -1,5 +1,6 @@
 import test from 'node:test'
-import assert from 'node:assert'
+import assert from 'node:assert/strict'
+import { parseStateKeys } from './parsers.js'
 
 test('parseStateKeys', () => {
   const a = `export function state () {
@@ -10,7 +11,7 @@ test('parseStateKeys', () => {
       todoList: null,
     }
   }`
-  assert.equal(['user', 'todoList'], parseStateKeys(a))
+  assert.deepStrictEqual(parseStateKeys(a), ['user', 'todoList'])
 
   const b = `export const state = () => ({
     user: {
@@ -24,5 +25,5 @@ test('parseStateKeys', () => {
     }
   }
   `
-  assert.equal(['user', 'todoList'], parseStateKeys(b))
+  assert.deepStrictEqual(parseStateKeys(b), ['user', 'todoList'])
 })

--- a/packages/fastify-react/plugin/preload.js
+++ b/packages/fastify-react/plugin/preload.js
@@ -4,7 +4,7 @@ import { join, isAbsolute, parse as parsePath } from 'node:path'
 const imageFileRE = /\.((png)|(jpg)|(svg)|(webp)|(gif))$/
 
 export async function closeBundle(resolvedBundle) {
-  if (this.environment.name !== 'client') {
+  if (this.environment.name !== 'client' || !resolvedBundle) {
     return
   }
   const { assetsInlineLimit } = this.environment.config.build

--- a/packages/fastify-react/plugin/virtual.js
+++ b/packages/fastify-react/plugin/virtual.js
@@ -4,7 +4,6 @@ import { findExports } from 'mlly'
 
 const virtualRoot = resolve(import.meta.dirname, '..', 'virtual')
 const virtualRootTS = resolve(import.meta.dirname, '..', 'virtual-ts')
-
 const virtualModules = [
   'mount.js',
   'resource.js',
@@ -46,7 +45,7 @@ export async function resolveId(id) {
       if (override) {
         return override
       }
-      return id
+      return `/$app/${virtual}`
     }
   }
 }

--- a/packages/fastify-react/plugin/virtual.test.js
+++ b/packages/fastify-react/plugin/virtual.test.js
@@ -1,0 +1,26 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { loadVirtualModule, prefix, resolveId } from './virtual.js'
+
+test('resolveId anchors built-in $app modules at the Vite root', async () => {
+  const resolved = await resolveId.call({ root: import.meta.dirname }, '$app/layouts.js')
+
+  assert.equal(resolved, '/$app/layouts.js')
+
+  const [, virtual] = resolved.split(prefix)
+  assert.equal(virtual, 'layouts.js')
+  assert.ok(loadVirtualModule(virtual).code.includes("import.meta.glob('/layouts/*.{jsx,tsx}')"))
+})
+
+test('resolveId leaves project overrides as real files', async (t) => {
+  const root = await mkdtemp(join(tmpdir(), 'fastify-react-virtual-'))
+  t.after(() => rm(root, { recursive: true, force: true }))
+
+  const override = join(root, 'layouts.js')
+  await writeFile(override, 'export default {}')
+
+  assert.equal(await resolveId.call({ root }, '$app/layouts.js'), override)
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,6 +159,46 @@ importers:
         specifier: 'catalog:'
         version: 8.0.16(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.4.2)(tsx@4.21.0)(yaml@2.9.0)
 
+  e2e/react-base:
+    dependencies:
+      '@fastify/react':
+        specifier: workspace:^
+        version: link:../../packages/fastify-react
+      '@fastify/vite':
+        specifier: workspace:^
+        version: link:../../packages/fastify-vite
+      '@unhead/react':
+        specifier: ^2.1.13
+        version: 2.1.13(react@19.2.4)
+      fastify:
+        specifier: 'catalog:'
+        version: 5.8.5
+      history:
+        specifier: latest
+        version: 5.3.0
+      minipass:
+        specifier: latest
+        version: 7.1.3
+      react:
+        specifier: catalog:react
+        version: 19.2.4
+      react-dom:
+        specifier: catalog:react
+        version: 19.2.4(react@19.2.4)
+      react-router:
+        specifier: catalog:react
+        version: 7.18.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      valtio:
+        specifier: latest
+        version: 2.3.2(@types/react@19.1.2)(react@19.2.4)
+    devDependencies:
+      '@vitejs/plugin-react':
+        specifier: catalog:react
+        version: 6.0.1(vite@8.0.16(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.4.2)(tsx@4.21.0)(yaml@2.9.0))
+      vite:
+        specifier: 'catalog:'
+        version: 8.0.16(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.4.2)(tsx@4.21.0)(yaml@2.9.0)
+
   e2e/react-hydration:
     dependencies:
       '@fastify/vite':
@@ -5232,6 +5272,18 @@ packages:
       react:
         optional: true
 
+  valtio@2.3.2:
+    resolution: {integrity: sha512-YXhWQei9IN/ZDce9rhL3trCq9+vVq8M1gWmKVdP3YSZ2gxsmmNWVbxXwf9yG6ffu/dAvAD91nevg8xirGr4Dhg==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      react: '>=18.0.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      react:
+        optional: true
+
   vfile-message@4.0.3:
     resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
 
@@ -6305,7 +6357,7 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       react-router: 7.18.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      valtio: 2.3.1(@types/react@19.1.2)(react@19.2.4)
+      valtio: 2.3.2(@types/react@19.1.2)(react@19.2.4)
       youch: 3.3.4
     transitivePeerDependencies:
       - '@types/react'
@@ -6326,7 +6378,7 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       react-router: 7.18.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      valtio: 2.3.1(@types/react@19.1.2)(react@19.2.4)
+      valtio: 2.3.2(@types/react@19.1.2)(react@19.2.4)
       youch: 3.3.4
     transitivePeerDependencies:
       - '@types/react'
@@ -9832,6 +9884,13 @@ snapshots:
     optional: true
 
   valtio@2.3.1(@types/react@19.1.2)(react@19.2.4):
+    dependencies:
+      proxy-compare: 3.0.1
+    optionalDependencies:
+      '@types/react': 19.1.2
+      react: 19.2.4
+
+  valtio@2.3.2(@types/react@19.1.2)(react@19.2.4):
     dependencies:
       proxy-compare: 3.0.1
     optionalDependencies:


### PR DESCRIPTION
Fixes #434 