### PR TITLE
docs: fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <br>
 
-<a href="https://fastify.github.io/fastify-vite/"><img src="https://github.com/fastify/fastify-vite/assets/12291/7f711a83-91df-41d5-abf9-ae4f38ed24d3" style="width: 250px"></a>
+<a href="https://vite.fastify.dev/"><img src="https://github.com/fastify/fastify-vite/assets/12291/7f711a83-91df-41d5-abf9-ae4f38ed24d3" style="width: 250px"></a>
 
 # **`@fastify/vite`**
 
@@ -8,7 +8,7 @@ This [Fastify](https://fastify.dev) plugin lets you:
 
 - run Vite's development server as middleware in your Fastify server
   - in development mode only, naturally
-- **expose** your [Vite](https://vitejs.dev) application to your Fastify application
+- **expose** your [Vite](https://vite.dev) application to your Fastify application
   - with configuration hooks to **ease router integration** and **other customizations**
 - automatically serve your Vite production bundle, inferred from a Vite configuration file.
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -127,7 +127,7 @@ export default {
 
 In `package.json`, take note of how the `dev`, `start` and `build` commands are defined, all just using your `server.js` file and Vite.
 
-Then for the client code, cleanly separated in the `client/` directory, you have `index.html` loading `mount.js`, `base.jsx` with a React component and `mount.js` loading it. Notice that Vite requires you to have an `index.html` file as it's [the front-and-central build entry point](https://vitejs.dev/guide/#index-html-and-project-root).
+Then for the client code, cleanly separated in the `client/` directory, you have `index.html` loading `mount.js`, `base.jsx` with a React component and `mount.js` loading it. Notice that Vite requires you to have an `index.html` file as it's [the front-and-central build entry point](https://vite.dev/guide/#index-html-and-project-root).
 
 ::: code-group
 
@@ -192,7 +192,7 @@ In all examples in this documentation, the client application code is kept in a 
 It's important to realize that in `server.js`, the `root` configuration option determines where your `vite.config.js` is located. But in `vite.config.js` itself, the `root` configuration option determines where your `index.html` is located. This is your **project root** in Vite's context.
 :::
 
-Regardless of whether you want to simply deliver a SPA bundle to the browser or perform SSR, projects using **`@fastify/vite`** will always need a minimum of **three files**: the Fastify **server**, an [index.html file](https://vitejs.dev/guide/#index-html-and-project-root) and a [Vite configuration file](https://vitejs.dev/config/).
+Regardless of whether you want to simply deliver a SPA bundle to the browser or perform SSR, projects using **`@fastify/vite`** will always need a minimum of **three files**: the Fastify **server**, an [index.html file](https://vite.dev/guide/#index-html-and-project-root) and a [Vite configuration file](https://vite.dev/config/).
 
 ## Architectural primitives
 

--- a/docs/guide/parts/links.md
+++ b/docs/guide/parts/links.md
@@ -2,7 +2,7 @@
 [react]: https://react.dev/
 [fastify-cli]: https://github.com/fastify/fastify-cli
 [fastify-static]: https://github.com/fastify/fastify-static
-[fastify-vite]: https://fastify.github.io/fastify-vite/
+[fastify-vite]: https://vite.fastify.dev/
 [fastify]: https://fastify.dev/
 [next]: https://nextjs.org/
 [nuxt]: https://nuxt.com/
@@ -14,5 +14,5 @@
 [react-vanilla]: https://github.com/fastify/fastify-vite/tree/main/e2e/react-vanilla
 [ssr-1]: https://hire.jonasgalvez.com.br/2022/apr/30/a-gentle-introduction-to-ssr/
 [ssr-2]: https://www.patterns.dev/react/server-side-rendering
-[vite]: https://vitejs.dev/
+[vite]: https://vite.dev/
 [vue-hydration]: https://github.com/fastify/fastify-vite/tree/main/e2e/vue-hydration

--- a/docs/guide/rendering-function.md
+++ b/docs/guide/rendering-function.md
@@ -7,7 +7,7 @@ If you're looking to perform [Server-Side Rendering (SSR)][ssr-1], or simply wan
 
 For example, if you're looking to perform SSR on a React application, you'll need access to your main React component on the server so you can use [`renderToString()`](https://react.dev/reference/react-dom/server/renderToString) (or [`renderToPipeableStream()`](https://react.dev/reference/react-dom/server/renderToPipeableStream) in an ideal scenario).
 
-When **@fastify/vite** loads your client module, be it via [`ssrLoadModule()`](https://vitejs.dev/guide/ssr.html#building-for-production) in development mode or straight from the production bundle (this is controlled via the `dev` configuration option), it is passed to the `prepareClient()` and `createRenderFunction()` configuration hooks.
+When **@fastify/vite** loads your client module, be it via [`ssrLoadModule()`](https://vite.dev/guide/ssr.html#building-for-production) in development mode or straight from the production bundle (this is controlled via the `dev` configuration option), it is passed to the `prepareClient()` and `createRenderFunction()` configuration hooks.
 
 The default behavior of `prepareClient()` is to just load the module as-is, but also execute `routes` in case it's provided as a function (this is for routing integration, covered later in this section). `createRenderFunction()` **does not** have a default definition, **it needs to be provided**.
 
@@ -28,7 +28,7 @@ await server.register(FastifyVite, {
 
 `createRenderFunction()` receives as the first parameter a reference to your **Vite application module**, i.e., your client application. The function it returns is added ([decorated](https://fastify.dev/docs/v2.15.x/Documentation/Decorators/)) to the Fastify `Reply` class as `render()`.
 
-**`@fastify/vite`** treats your Vite project root as a JavaScript module, so it'll automatically look for `index.js` as the **server entry point**, that is, the module that's gets [bundled for production](https://vitejs.dev/guide/ssr.html#building-for-production) in [**SSR mode**](https://vitejs.dev/config/build-options.html#build-ssr) by Vite.
+**`@fastify/vite`** treats your Vite project root as a JavaScript module, so it'll automatically look for `index.js` as the **server entry point**, that is, the module that's gets [bundled for production](https://vite.dev/guide/ssr.html#building-for-production) in [**SSR mode**](https://vite.dev/config/build-options.html#build-ssr) by Vite.
 
 This is what **Vite application module** or **client module** refers to.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@ layout: home
 hero:
   name: '@fastify/vite'
   text: 'Titans Combined'
-  tagline: Cleanly and elegantly integrate <b><a href="https://fastify.dev/" target="_blank">Fastify</a></b> and <b><a href="https://vitejs.dev/" target="_blank">Vite</a></b> to create a <b>minimal</b>, <b>low overhead</b> setup for <b>full stack monoliths</b>.
+  tagline: Cleanly and elegantly integrate <b><a href="https://fastify.dev/" target="_blank">Fastify</a></b> and <b><a href="https://vite.dev/" target="_blank">Vite</a></b> to create a <b>minimal</b>, <b>low overhead</b> setup for <b>full stack monoliths</b>.
   actions:
     - theme: brand
       text: Get Started

--- a/docs/react/index.md
+++ b/docs/react/index.md
@@ -42,7 +42,7 @@ giget gh:fastify/fastify-vite/starters/react-base your-app
 
 - [**`fastify`**](https://github.com/fastify/fastify) as the **Node.js** server.
 
-- [**`vite`**](https://vitejs.dev/) for the client application bundling.
+- [**`vite`**](https://vite.dev) for the client application bundling.
 
 - [**`@fastify/vite`**](https://github.com/fastify/fastify-vite) for Vite integration in Fastify.
   - And its peer dependencies:

--- a/docs/react/project-structure.md
+++ b/docs/react/project-structure.md
@@ -216,7 +216,7 @@ In this example, `server.js` is the Fastify server and also the place where both
 
 Like in any `@fastify/vite` application, `client/index.js` are the portions of your client code that get loaded by the server. It exports your application's factory function (`create`), the application routes and the [route context](/react/route-context) initialization module, all loaded via [smart imports](/react/project-structure#smart-imports), covered later on this page.
 
-Notice that `client/index.html` needs to exist as the [front-and-central entry point](https://vitejs.dev/guide/#index-html-and-project-root) of your application, and `@fastify/react` has its own structure for it.
+Notice that `client/index.html` needs to exist as the [front-and-central entry point](https://vite.dev/guide/#index-html-and-project-root) of your application, and `@fastify/react` has its own structure for it.
 
 Also notice that in `vite.config.js`, `@fastify/react/plugin` needs to be registered so that [**smart imports**](/react/project-structure#smart-imports) can work.
 

--- a/docs/vue/index.md
+++ b/docs/vue/index.md
@@ -44,7 +44,7 @@ giget gh:fastify/fastify-vite/starters/vue-base your-app
 
 - [**`fastify`**](https://github.com/fastify/fastify) as the **Node.js** server.
 
-- [**`vite`**](https://vitejs.dev/) for the client application bundling.
+- [**`vite`**](https://vite.dev) for the client application bundling.
 
 - [**`@fastify/vite`**](https://github.com/fastify/fastify-vite) for Vite integration in Fastify.
 

--- a/docs/vue/project-structure.md
+++ b/docs/vue/project-structure.md
@@ -225,7 +225,7 @@ In this example, `server.js` is the Fastify server and also the place where both
 
 Like in any `@fastify/vite` application, `client/index.js` are the portions of your client code that get loaded by the server. It exports your application's factory function (`create`), the application routes and the [route context](/vue/route-context) initialization module, all loaded via [smart imports](/vue/project-structure#smart-imports), covered later on this page.
 
-Notice that `client/index.html` needs to exist as the [front-and-central entry point](https://vitejs.dev/guide/#index-html-and-project-root) of your application, and `@fastify/vue` has its own structure for it.
+Notice that `client/index.html` needs to exist as the [front-and-central entry point](https://vite.dev/guide/#index-html-and-project-root) of your application, and `@fastify/vue` has its own structure for it.
 
 Also notice that in `vite.config.js`, `@fastify/vue/plugin` needs to be registered so that [**smart imports**](/vue/project-structure#smart-imports) can work.
 

--- a/packages/fastify-react/README.md
+++ b/packages/fastify-react/README.md
@@ -2,4 +2,4 @@
 
 **`@fastify/react`** is the official [**`@fastify/vite`**](https://github.com/fastify/fastify-vite) renderer for React.
 
-See the [documentation suite](https://fastify.github.io/fastify-vite/react/) to learn more.
+See the [documentation suite](https://vite.fastify.dev/react/) to learn more.

--- a/packages/fastify-vite/README.md
+++ b/packages/fastify-vite/README.md
@@ -4,6 +4,6 @@
 
 # **`@fastify/vite`**
 
-This [Fastify](https://fastify.dev) plugin allows you to run Vite's development server as middleware, **expose** your [Vite](https://vitejs.dev) application to your Fastify application, with configuration hooks to **ease router integration** and **other customizations**, and also automatically serve Vite builds, inferred from a Vite configuration file.
+This [Fastify](https://fastify.dev) plugin allows you to run Vite's development server as middleware, **expose** your [Vite](https://vite.dev) application to your Fastify application, with configuration hooks to **ease router integration** and **other customizations**, and also automatically serve Vite builds, inferred from a Vite configuration file.
 
-See the [full documentation suite](https://fastify.github.io/fastify-vite/) to learn more.
+See the [full documentation suite](https://vite.fastify.dev/) to learn more.

--- a/packages/fastify-vue/README.md
+++ b/packages/fastify-vue/README.md
@@ -2,4 +2,4 @@
 
 **`@fastify/vue`** is the official [**`@fastify/vite`**](https://github.com/fastify/fastify-vite) renderer for Vue.
 
-See the [documentation suite](https://fastify.github.io/fastify-vite/vue/) to learn more.
+See the [documentation suite](https://vite.fastify.dev/vue/) to learn more.

--- a/starters/react-base/README.md
+++ b/starters/react-base/README.md
@@ -1,3 +1,3 @@
 <br>
 
-The official **[@fastify/react](https://fastify.github.io/fastify-vite/react/)** basic starter template.
+The official **[@fastify/react](https://vite.fastify.dev/react/)** basic starter template.

--- a/starters/react-kitchensink/README.md
+++ b/starters/react-kitchensink/README.md
@@ -1,3 +1,3 @@
 <br>
 
-The official **[@fastify/react](https://fastify.github.io/fastify-vite/react/)** starter template.
+The official **[@fastify/react](https://vite.fastify.dev/react/)** starter template.

--- a/starters/react-typescript/README.md
+++ b/starters/react-typescript/README.md
@@ -1,3 +1,3 @@
 <br>
 
-The official **[@fastify/react](https://fastify.github.io/fastify-vite/react/)** starter template.
+The official **[@fastify/react](https://vite.fastify.dev/react/)** starter template.

--- a/starters/vue-base/README.md
+++ b/starters/vue-base/README.md
@@ -1,3 +1,3 @@
 <br>
 
-The official **[@fastify/vue](https://fastify.github.io/fastify-vite/vue/)** base starter template.
+The official **[@fastify/vue](https://vite.fastify.dev/vue/)** base starter template.

--- a/starters/vue-kitchensink/README.md
+++ b/starters/vue-kitchensink/README.md
@@ -1,3 +1,3 @@
 <br>
 
-The official **[@fastify/vue](https://fastify.github.io/fastify-vite/vue/)** advanced starter template.
+The official **[@fastify/vue](https://vite.fastify.dev/vue/)** advanced starter template.

--- a/starters/vue-typescript/README.md
+++ b/starters/vue-typescript/README.md
@@ -1,3 +1,3 @@
 <br>
 
-The official **[@fastify/vue](https://fastify.github.io/fastify-vite/vue/)** advanced starter template.
+The official **[@fastify/vue](https://vite.fastify.dev/vue/)** advanced starter template.


### PR DESCRIPTION
Fixes 404s, 3xx redirections, and missing fragments in the documentation. Part of general link cleanup being tracked in https://github.com/fastify/accept-negotiator/pull/71