### PR TITLE
refactor: iterate viteConfig.environments directly instead of re-invoking plugin config hook

### DIFF
--- a/.changeset/huge-planets-do.md
+++ b/.changeset/huge-planets-do.md
@@ -1,0 +1,7 @@
+---
+'@fastify/vite': patch
+---
+
+Refactor environment discovery to iterate `viteConfig.environments` directly
+
+Replaces the fragile `findPlugin`/`hasPlugin` config-hook re-invocation pattern with direct iteration of `viteConfig.environments`, which is always available after Vite resolves its config. Also uses `isRunnableDevEnvironment(envConfig).runner` where available to avoid creating duplicate `ModuleRunner` instances for cross-environment imports.

--- a/packages/fastify-vite/src/mode/development.test.ts
+++ b/packages/fastify-vite/src/mode/development.test.ts
@@ -42,6 +42,15 @@ describe('loadEntries', () => {
       viteConfig: {
         root: '/test',
         plugins: [{ name: 'vite-fastify', config: vi.fn() }] as unknown[],
+        environments: {
+          ssr: {
+            build: {
+              rollupOptions: {
+                input: { index: '/test/server.js' },
+              },
+            },
+          },
+        },
       },
       virtualModulePrefix: 'virtual:',
       prepareClient: vi.fn().mockResolvedValue({}),

--- a/packages/fastify-vite/src/mode/development.ts
+++ b/packages/fastify-vite/src/mode/development.ts
@@ -1,7 +1,7 @@
 import { readFile } from 'node:fs/promises'
 import { join, resolve } from 'node:path'
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify'
-import { createServer, createServerModuleRunner } from 'vite'
+import { createServer, createServerModuleRunner, isRunnableDevEnvironment } from 'vite'
 import middie, { type Handler as MiddieHandler } from '@fastify/middie'
 import type { ClientModule } from '../types/client.ts'
 import type { DevRuntimeConfig } from '../types/options.ts'
@@ -71,9 +71,14 @@ export async function loadEntries(
     }
 
     // Reuse existing runner or create a new one
+    // Use the environment's own runner (RunnableDevEnvironment.runner) where available
+    // to avoid creating a second ModuleRunner instance later when @vitejs/plugin-rsc
+    // performs cross-environment imports via import.meta.viteRsc.import('ssr', ...).
     let runner = fastifyViteDecoration.runners[env]
     if (!runner) {
-      runner = createServerModuleRunner(envConfig)
+      runner = isRunnableDevEnvironment(envConfig)
+        ? envConfig.runner
+        : createServerModuleRunner(envConfig)
       fastifyViteDecoration.runners[env] = runner
     }
 

--- a/packages/fastify-vite/src/mode/development.ts
+++ b/packages/fastify-vite/src/mode/development.ts
@@ -1,7 +1,6 @@
 import { readFile } from 'node:fs/promises'
 import { join, resolve } from 'node:path'
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify'
-import type { Plugin as VitePlugin, ResolvedConfig } from 'vite'
 import { createServer, createServerModuleRunner } from 'vite'
 import middie, { type Handler as MiddieHandler } from '@fastify/middie'
 import type { ClientModule } from '../types/client.ts'
@@ -10,22 +9,6 @@ import type { RouteDefinition } from '../types/route.ts'
 import { hasIterableRoutes, type FastifyViteDecorationPriorToSetup } from './support.ts'
 
 export const hot = Symbol('hotModuleReplacementProxy')
-
-interface ViteEnvironmentsConfig {
-  root: string
-  environments: Record<
-    string,
-    {
-      build?: {
-        rollupOptions?: {
-          input?: {
-            index?: string
-          }
-        }
-      }
-    }
-  >
-}
 
 interface HotState {
   client?: ClientModule | null
@@ -46,51 +29,24 @@ interface LoadedEntryModule {
 async function loadEntryModulePaths(
   runtimeConfig: DevRuntimeConfig,
 ): Promise<Record<string, string> | null> {
-  if (runtimeConfig.spa) {
-    return null
-  }
-  const entryModulePaths: Record<string, string> = {}
+  if (runtimeConfig.spa) return null
 
   const { viteConfig } = runtimeConfig
+  const result: Record<string, string> = {}
 
-  if (!hasPlugin(viteConfig, 'vite-fastify')) {
-    throw new Error("@fastify/vite's Vite plugin not registered")
+  for (const [envName, env] of Object.entries(viteConfig.environments ?? {})) {
+    if (envName === 'client') continue
+    const input = env.build?.rollupOptions?.input
+    if (!input) continue
+    const entry = Object.values(input).find(Boolean) as string | undefined
+    if (!entry) continue
+    // Strip Vite's \0 virtual module prefix before checking against virtualModulePrefix
+    const cleanPath = entry.charCodeAt(0) === 0 ? entry.slice(1) : entry
+    result[envName] = cleanPath.startsWith(runtimeConfig.virtualModulePrefix)
+      ? cleanPath
+      : resolve(viteConfig.root, cleanPath.replace(/^\/+/, ''))
   }
-
-  const plugin = findPlugin(viteConfig, 'vite-fastify')
-  const configHook = plugin.config
-
-  const setupEnvironments = typeof configHook === 'function' ? configHook : configHook?.handler
-  if (!setupEnvironments) {
-    throw new Error("@fastify/vite's Vite plugin has no config hook")
-  }
-
-  const viteEnvsConfig: ViteEnvironmentsConfig = {
-    root: viteConfig.root,
-    environments: {},
-  }
-
-  await setupEnvironments.call({} as never, viteEnvsConfig, {
-    mode: 'development',
-    command: 'serve',
-  })
-
-  const { client: _, ...nonClientEnvs } = Object.fromEntries(
-    Object.keys(viteEnvsConfig.environments).map((env) => [env, 1]),
-  )
-
-  for (const env of Object.keys(nonClientEnvs)) {
-    const environment = viteEnvsConfig.environments[env]
-    if (environment.build?.rollupOptions?.input?.index) {
-      const modulePath = environment.build.rollupOptions.input.index.startsWith(
-        runtimeConfig.virtualModulePrefix,
-      )
-        ? environment.build.rollupOptions.input.index
-        : resolve(viteConfig.root, environment.build.rollupOptions.input.index.replace(/^\/+/, ''))
-      entryModulePaths[env] = modulePath
-    }
-  }
-  return entryModulePaths
+  return Object.keys(result).length > 0 ? result : null
 }
 
 export async function loadEntries(
@@ -240,35 +196,4 @@ export async function setup(
   const client = clientResult ? (clientResult as ClientModule) : null
 
   return client
-}
-
-function findPlugin(config: ResolvedConfig, pluginName: string): VitePlugin {
-  for (const plugin of config.plugins) {
-    if (Array.isArray(plugin)) {
-      for (const subPlugin of plugin) {
-        if ((subPlugin as VitePlugin).name === pluginName) {
-          return subPlugin as VitePlugin
-        }
-      }
-    }
-    if ((plugin as VitePlugin).name === pluginName) {
-      return plugin as VitePlugin
-    }
-  }
-  const found = config.plugins.some((_) => {
-    if (Array.isArray(_)) {
-      return _.some((__) => (__ as VitePlugin).name === pluginName)
-    }
-    return (_ as VitePlugin).name === pluginName
-  })
-  return found ? ({} as VitePlugin) : ({} as VitePlugin)
-}
-
-function hasPlugin(config: ResolvedConfig, pluginName: string): boolean {
-  return config.plugins.some((_) => {
-    if (Array.isArray(_)) {
-      return _.some((__) => (__ as VitePlugin).name === pluginName)
-    }
-    return (_ as VitePlugin).name === pluginName
-  })
 }

--- a/packages/fastify-vite/src/plugin.ts
+++ b/packages/fastify-vite/src/plugin.ts
@@ -100,13 +100,17 @@ export function viteFastify(options: ViteFastifyPluginOptions = {}): Plugin {
         Object.entries(resolvedConfig.environments)
           .map(([env, envConfig]) => {
             const envBuild = envConfig.build as
-              | { outDir?: string; rollupOptions?: { input?: { index?: string } } }
+              | { outDir?: string; rollupOptions?: { input?: Record<string, string> } }
               | undefined
             if (envBuild?.outDir) {
               fastify.outDirs![env] = envBuild.outDir
             }
-            if (envBuild?.rollupOptions?.input?.index) {
-              return [env, envBuild.rollupOptions.input.index]
+            const input = envBuild?.rollupOptions?.input
+            if (input) {
+              const entry = Object.values(input).find(Boolean)
+              if (entry) {
+                return [env, entry]
+              }
             }
             return false
           })


### PR DESCRIPTION
## Refactor environment discovery to iterate `viteConfig.environments` directly

Removes the fragile `findPlugin` / `hasPlugin` pattern that re-invoked the plugin's config hook to discover environment entry paths. Instead, reads `viteConfig.environments` directly — the same source of truth Vite already provides.

### Why

The old approach called the plugin's `config` hook a second time at runtime to reconstruct environment configuration. This broke when another plugin (like `@vitejs/plugin-rsc`) modified the same environments during its own `config` hook — the re-invocation could produce a different result or fail outright.

The new approach iterates `viteConfig.environments` directly, which is always available after Vite resolves its config. No plugin introspection needed.

### Changes

- **`development.ts` (environment config)** — `loadEntryModulePaths()` now walks `viteConfig.environments` directly, instead of re-invoking the plugin's config hook on a synthetic object. Removes the `findPlugin`/`hasPlugin` introspection helpers and the `ViteEnvironmentsConfig` interface. Because the new path reads already-resolved config, it also strips Vite's internal `\0` null-byte prefix from virtual module IDs. The file deletes ~90 lines total. Returns `null` (not `{}`) when no environments match — the caller handles both identically.

- **`development.ts` (runner reuse)** — `loadEntries()` uses `isRunnableDevEnvironment(envConfig).runner` where available, falling back to `createServerModuleRunner()`. Avoids creating a duplicate `ModuleRunner` when `@vitejs/plugin-rsc` later accesses `envConfig.runner` via its lazy getter for cross-environment imports.

- **`plugin.ts`** — Generalizes `rollupOptions.input` from `{ index?: string }` to `Record<string, string>`. Iterates all input entries, not just the one named `index`. Required when Vite environments register entries under non-standard names.

- **`development.test.ts`** — Adds `environments` field to the mock config so `loadEntryModulePaths` is exercised as intended.

### Verification

- All 86 tests pass (78 runtime + 8 typecheck)
- `tsc` build produces no errors
- No breaking changes — iterates environments that always exist in Vite 8, falls back gracefully (returns `null`) when none match