### PR TITLE
Fix problem with multiple params

### DIFF
--- a/.changeset/rare-taxis-strive.md
+++ b/.changeset/rare-taxis-strive.md
@@ -1,0 +1,5 @@
+---
+"@fastify/react": patch
+---
+
+Fixes multiple route parameters not expanding

--- a/packages/fastify-react/package.json
+++ b/packages/fastify-react/package.json
@@ -63,7 +63,7 @@
     "access": "public"
   },
   "scripts": {
-    "test": "node --test plugin/*.test.js"
+    "test": "node --test plugin/*.test.js server.test.js"
   },
   "dependencies": {
     "@fastify/vite": "workspace:^",

--- a/packages/fastify-react/server.js
+++ b/packages/fastify-react/server.js
@@ -39,7 +39,7 @@ export function prepareServer(server) {
   })
 }
 
-export async function createRoutes(fromPromise, { param } = { param: /\[([.\w]+\+?)\]/ }) {
+export async function createRoutes(fromPromise, { param } = { param: /\[([.\w]+\+?)\]/g }) {
   const { default: from } = await fromPromise
   const importPaths = Object.keys(from)
   const promises = []

--- a/packages/fastify-react/server.test.js
+++ b/packages/fastify-react/server.test.js
@@ -1,0 +1,23 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { createRoutes } from './server.js'
+
+test('createRoutes converts every dynamic segment in a route path', async () => {
+  const routes = await createRoutes(
+    Promise.resolve({
+      default: {
+        '/pages/[level]/singular/[second]/third/[fourth].tsx': async () => ({
+          default: () => null,
+        }),
+        '/pages/[level]/wildcard/[slug+].tsx': async () => ({
+          default: () => null,
+        }),
+      },
+    }),
+  )
+
+  assert.deepEqual(Array.from(routes, (route) => route.path).sort(), [
+    '/:level/singular/:second/third/:fourth',
+    '/:level/wildcard/*',
+  ])
+})


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

This addresses a problem where multiple nested parameters only ended up having the first parameter correctly converted for the path, causing the later params to be interpreted as literals. 

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
