### PR TITLE
ci: add Dependabot config for automated dependency updates

### DIFF
--- a/.changeset/add-dependabot-config.md
+++ b/.changeset/add-dependabot-config.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add Dependabot configuration to automate weekly dependency updates across all npm ecosystems and GitHub Actions.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
     groups:
       all-dependencies:
         patterns:
-          - "*"
+          - '*'
 
   - package-ecosystem: npm
     directory: /e2e/vue-hydration
@@ -16,7 +16,7 @@ updates:
     groups:
       all-dependencies:
         patterns:
-          - "*"
+          - '*'
 
   - package-ecosystem: npm
     directory: /e2e/react-base
@@ -25,7 +25,7 @@ updates:
     groups:
       all-dependencies:
         patterns:
-          - "*"
+          - '*'
 
   - package-ecosystem: npm
     directory: /e2e/react-next-mini
@@ -34,7 +34,7 @@ updates:
     groups:
       all-dependencies:
         patterns:
-          - "*"
+          - '*'
 
   - package-ecosystem: npm
     directory: /e2e/react-streaming
@@ -43,7 +43,7 @@ updates:
     groups:
       all-dependencies:
         patterns:
-          - "*"
+          - '*'
 
   - package-ecosystem: npm
     directory: /e2e/vue-vanilla-spa
@@ -52,7 +52,7 @@ updates:
     groups:
       all-dependencies:
         patterns:
-          - "*"
+          - '*'
 
   - package-ecosystem: npm
     directory: /e2e/react-vanilla-spa-ts
@@ -61,7 +61,7 @@ updates:
     groups:
       all-dependencies:
         patterns:
-          - "*"
+          - '*'
 
   - package-ecosystem: npm
     directory: /e2e/react-vanilla-ts
@@ -70,7 +70,7 @@ updates:
     groups:
       all-dependencies:
         patterns:
-          - "*"
+          - '*'
 
   - package-ecosystem: npm
     directory: /e2e/react-vanilla-spa
@@ -79,7 +79,7 @@ updates:
     groups:
       all-dependencies:
         patterns:
-          - "*"
+          - '*'
 
   - package-ecosystem: npm
     directory: /e2e/vue-vanilla
@@ -88,7 +88,7 @@ updates:
     groups:
       all-dependencies:
         patterns:
-          - "*"
+          - '*'
 
   - package-ecosystem: npm
     directory: /e2e/vue-streaming
@@ -97,7 +97,7 @@ updates:
     groups:
       all-dependencies:
         patterns:
-          - "*"
+          - '*'
 
   - package-ecosystem: npm
     directory: /e2e/middie-compat
@@ -106,7 +106,7 @@ updates:
     groups:
       all-dependencies:
         patterns:
-          - "*"
+          - '*'
 
   - package-ecosystem: npm
     directory: /e2e/static-options
@@ -115,7 +115,7 @@ updates:
     groups:
       all-dependencies:
         patterns:
-          - "*"
+          - '*'
 
   - package-ecosystem: npm
     directory: /e2e/vue-next-mini
@@ -124,7 +124,7 @@ updates:
     groups:
       all-dependencies:
         patterns:
-          - "*"
+          - '*'
 
   - package-ecosystem: npm
     directory: /e2e/vue-vanilla-ts
@@ -133,7 +133,7 @@ updates:
     groups:
       all-dependencies:
         patterns:
-          - "*"
+          - '*'
 
   - package-ecosystem: npm
     directory: /e2e/prefix-support
@@ -142,7 +142,7 @@ updates:
     groups:
       all-dependencies:
         patterns:
-          - "*"
+          - '*'
 
   - package-ecosystem: npm
     directory: /e2e/react-hydration
@@ -151,7 +151,7 @@ updates:
     groups:
       all-dependencies:
         patterns:
-          - "*"
+          - '*'
 
   - package-ecosystem: npm
     directory: /e2e/react-vanilla
@@ -160,7 +160,7 @@ updates:
     groups:
       all-dependencies:
         patterns:
-          - "*"
+          - '*'
 
   - package-ecosystem: npm
     directory: /starters/react-base
@@ -169,7 +169,7 @@ updates:
     groups:
       all-dependencies:
         patterns:
-          - "*"
+          - '*'
 
   - package-ecosystem: npm
     directory: /starters/react-kitchensink
@@ -178,7 +178,7 @@ updates:
     groups:
       all-dependencies:
         patterns:
-          - "*"
+          - '*'
 
   - package-ecosystem: npm
     directory: /starters/vue-base
@@ -187,7 +187,7 @@ updates:
     groups:
       all-dependencies:
         patterns:
-          - "*"
+          - '*'
 
   - package-ecosystem: npm
     directory: /starters/react-typescript
@@ -196,7 +196,7 @@ updates:
     groups:
       all-dependencies:
         patterns:
-          - "*"
+          - '*'
 
   - package-ecosystem: npm
     directory: /starters/vue-typescript
@@ -205,7 +205,7 @@ updates:
     groups:
       all-dependencies:
         patterns:
-          - "*"
+          - '*'
 
   - package-ecosystem: npm
     directory: /starters/vue-kitchensink
@@ -214,7 +214,7 @@ updates:
     groups:
       all-dependencies:
         patterns:
-          - "*"
+          - '*'
 
   - package-ecosystem: npm
     directory: /docs
@@ -223,7 +223,7 @@ updates:
     groups:
       all-dependencies:
         patterns:
-          - "*"
+          - '*'
 
   - package-ecosystem: npm
     directory: /packages/fastify-htmx
@@ -232,7 +232,7 @@ updates:
     groups:
       all-dependencies:
         patterns:
-          - "*"
+          - '*'
 
   - package-ecosystem: npm
     directory: /packages/fastify-react
@@ -241,7 +241,7 @@ updates:
     groups:
       all-dependencies:
         patterns:
-          - "*"
+          - '*'
 
   - package-ecosystem: npm
     directory: /packages/fastify-vite
@@ -250,7 +250,7 @@ updates:
     groups:
       all-dependencies:
         patterns:
-          - "*"
+          - '*'
 
   - package-ecosystem: npm
     directory: /packages/fastify-vue
@@ -259,7 +259,7 @@ updates:
     groups:
       all-dependencies:
         patterns:
-          - "*"
+          - '*'
 
   - package-ecosystem: npm
     directory: /
@@ -268,7 +268,7 @@ updates:
     groups:
       all-dependencies:
         patterns:
-          - "*"
+          - '*'
 
   - package-ecosystem: github-actions
     directory: /
@@ -277,4 +277,4 @@ updates:
     groups:
       all-dependencies:
         patterns:
-          - "*"
+          - '*'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,280 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /e2e/relative-outdir
+    schedule:
+      interval: weekly
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: /e2e/vue-hydration
+    schedule:
+      interval: weekly
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: /e2e/react-base
+    schedule:
+      interval: weekly
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: /e2e/react-next-mini
+    schedule:
+      interval: weekly
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: /e2e/react-streaming
+    schedule:
+      interval: weekly
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: /e2e/vue-vanilla-spa
+    schedule:
+      interval: weekly
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: /e2e/react-vanilla-spa-ts
+    schedule:
+      interval: weekly
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: /e2e/react-vanilla-ts
+    schedule:
+      interval: weekly
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: /e2e/react-vanilla-spa
+    schedule:
+      interval: weekly
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: /e2e/vue-vanilla
+    schedule:
+      interval: weekly
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: /e2e/vue-streaming
+    schedule:
+      interval: weekly
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: /e2e/middie-compat
+    schedule:
+      interval: weekly
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: /e2e/static-options
+    schedule:
+      interval: weekly
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: /e2e/vue-next-mini
+    schedule:
+      interval: weekly
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: /e2e/vue-vanilla-ts
+    schedule:
+      interval: weekly
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: /e2e/prefix-support
+    schedule:
+      interval: weekly
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: /e2e/react-hydration
+    schedule:
+      interval: weekly
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: /e2e/react-vanilla
+    schedule:
+      interval: weekly
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: /starters/react-base
+    schedule:
+      interval: weekly
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: /starters/react-kitchensink
+    schedule:
+      interval: weekly
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: /starters/vue-base
+    schedule:
+      interval: weekly
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: /starters/react-typescript
+    schedule:
+      interval: weekly
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: /starters/vue-typescript
+    schedule:
+      interval: weekly
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: /starters/vue-kitchensink
+    schedule:
+      interval: weekly
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: /docs
+    schedule:
+      interval: weekly
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: /packages/fastify-htmx
+    schedule:
+      interval: weekly
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: /packages/fastify-react
+    schedule:
+      interval: weekly
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: /packages/fastify-vite
+    schedule:
+      interval: weekly
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: /packages/fastify-vue
+    schedule:
+      interval: weekly
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
Add `.github/dependabot.yml` to enable automated weekly dependency updates across all npm package directories and GitHub Actions workflows.

The repo has 31 `package.json` manifests (packages, starters, e2e fixtures, docs) and GitHub Actions workflows with no existing automation to keep them current. Dependabot will open grouped PRs once a week per ecosystem, reducing manual update toil and keeping transitive dependency security patches flowing.

Configuration choices:
- **Schedule**: weekly — good balance between staying current and reducing PR noise
- **Grouped updates**: all dependencies per ecosystem batched into a single PR

This change was generated by [Autar](https://autar.ai) and reviewed by a human before submission.