### PR TITLE
ci: fix release workflow after changesets/action v2 bump

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,14 +45,14 @@ jobs:
         id: changesets
         uses: changesets/action@8488615a623b1b9c987934bb89eae8af6a946ac1 # v2.1.1
         with:
-          publish: pnpm changeset publish
+          publish-script: pnpm changeset publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Wait for Published Packages
         if: steps.changesets.outputs.published == 'true'
         env:
-          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
+          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.published-packages }}
         run: pnpm wait-for-published-packages
 
       - name: Prepare Published Packages


### PR DESCRIPTION
Proposal:

The Release workflow fails immediately with:

    Error: The following inputs have been renamed:
    - "publish" -> "publish-script"

The bump to `changesets/action` v2.1.1 was done without updating the workflow. v2 renamed inputs and outputs to kebab-case:

- input `publish` → `publish-script`
- output `publishedPackages` → `published-packages` (used by the "Wait for Published Packages" step; an unknown output silently resolves to an empty string, so this would have broken later)

The `published` output is unchanged. `@changesets/cli` is already v3, as required by v2 of the action.